### PR TITLE
CI actions for build and release

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,0 +1,52 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+template: |
+  ## Changes
+  $CHANGES
+  ## Contributors
+  $CONTRIBUTORS
+  
+exclude-labels:
+  - 'skip-changelog'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+autolabeler:
+  - label: 'chore'
+    files:
+      - '*.md'
+    branch:
+      - '/docs{0,1}\/.+/'
+      - '/gh-pages\/.+/'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+      - 'issues\/.+/'
+    title:
+      - '/fix/i'
+      - 'issues/i'
+  - label: 'enhancement'
+    branch:
+      - '/feature\/.+/'
+      - '/new\/.+/'

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,0 +1,93 @@
+name: Release Build
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      rebuild:
+        description: 'A tag name for building previously created release'
+        required: false
+        default: '0.0.0'
+
+jobs:
+  release:
+    runs-on: self-hosted
+    outputs:
+      version: ${{steps.get-version.outputs.version}}
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Check version
+        id: get-version
+        run: |
+          if [[ "${{ github.event.action }}" == "published" ]]
+            then
+              VERSION="${{ github.event.release.tag_name }}"
+            else
+              LATEST=`git describe --abbrev=0 --tags`
+              VERSION=`echo ${LATEST} | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g'`-${{ github.sha }}
+          fi
+          echo ::set-output name=version::${VERSION}
+      - name: Cache local Gradle repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-Gradle-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-Gradle-
+      - name: Set up JDK 13
+        uses: actions/setup-java@v2
+        with:
+          java-version: '13'
+          distribution: 'adopt'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Build with Gradle
+        env:
+          CI: false
+        run: |
+          ./gradlew clean build --scan -P version=${{ steps.get-version.outputs.version }}
+  charts:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - uses: azure/setup-helm@v1
+      - name: update appVersion
+        run: |
+          export version=${{needs.release.outputs.version}}
+          sed -i "s/appVersion:.*/appVersion: ${version}/" charts/odd-platform/Chart.yaml
+      - name: add chart
+        if: ${{ github.event.action == 'published' }}
+        run: |
+          export VERSION=${{needs.release.outputs.version}}
+          MSG=$(helm package --app-version ${VERSION} charts/odd-platform)
+          git fetch origin
+          git stash
+          git checkout -b gh-pages origin/gh-pages
+          helm repo index .
+          git add -f ${MSG##*/} index.yaml
+          git commit -m "release ${VERSION}"
+          git push

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        with:
+          config-name: release-drafter.yaml
+          disable-autolabeler: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/odd-platform-api/build.gradle
+++ b/odd-platform-api/build.gradle
@@ -5,7 +5,8 @@ plugins {
 }
 
 group = 'com.provectus'
-version = '0.0.1-SNAPSHOT'
+version = "${version != 'unspecified' ? version : '0.0.1-SNAPSHOT'}"
+
 sourceCompatibility = '13'
 
 apply from: 'jooq.generate.gradle'


### PR DESCRIPTION
- add the ability to define project version as Gradle command-line option
- add release drafter to sync draft release with pushes in developing period
- add base release pipeline 

The strategies of release:
- Regular release: after completing required milestones we switch GH release from draft state to published, this action will trigger release build pipeline
- Custom version: need to trigger manually release build action and specify the branch to build and version

The version is incremented automatically after GH release is published, all snapshot builds after release be builder as `<next-release-version>-<commit-sha>`