### PR TITLE
Bug fix: DataEntity tabs move to the page of the previous entity

### DIFF
--- a/odd-platform-ui/src/components/DataEntityDetails/DataEntityDetails.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DataEntityDetails.tsx
@@ -39,6 +39,7 @@ interface DataEntityDetailsProps extends StylesType {
   dataEntityId: number;
   dataEntityDetails: DataEntityDetails;
   isDataset: boolean;
+  isQualityTest: boolean;
   fetchDataEntityDetails: (
     params: DataEntityApiGetDataEntityDetailsRequest
   ) => void;
@@ -52,56 +53,62 @@ const DataEntityDetailsView: React.FC<DataEntityDetailsProps> = ({
   dataEntityId,
   dataEntityDetails,
   isDataset,
+  isQualityTest,
   fetchDataEntityDetails,
   dataEntityFetchingStatus,
-  dataEntityFetchingError
+  dataEntityFetchingError,
 }) => {
-  const [tabs, setTabs] = React.useState<AppTabItem[]>([
-    {
-      name: 'Overview',
-      link: dataEntityOverviewPath(dataEntityId),
-      value: 'overview',
-    },
-    {
-      name: 'Structure',
-      link: datasetStructurePath(dataEntityId),
-      hidden: true,
-      value: 'structure',
-    },
-    {
-      name: 'Lineage',
-      link: dataEntityLineagePath(dataEntityId),
-      value: 'lineage',
-    },
-    {
-      name: 'Test reports',
-      link: dataEntityTestReportPath(dataEntityId),
-      hidden: true,
-      value: 'test-reports',
-    },
-    {
-      name: 'Alerts',
-      link: dataEntityAlertsPath(dataEntityId),
-      value: 'alerts',
-    },
-  ]);
-
-  const [selectedTab, setSelectedTab] = React.useState<number>(-1);
-
-  React.useEffect(() => {
-    fetchDataEntityDetails({ dataEntityId });
-  }, [fetchDataEntityDetails, dataEntityId]);
+  const [tabs, setTabs] = React.useState<AppTabItem[]>([]);
 
   React.useEffect(() => {
     setTabs(
       tabs.map(tab => ({
         ...tab,
         hidden:
-          (tab.value === 'structure' || tab.value === 'test-reports') &&
-          !isDataset,
+          ((tab.value === 'structure' || tab.value === 'test-reports') &&
+            !isDataset) ||
+          (tab.value === 'lineage' && isQualityTest),
       }))
     );
-  }, [dataEntityDetails]);
+  }, [isDataset, dataEntityDetails]);
+
+  React.useEffect(() => {
+    setTabs([
+      {
+        name: 'Overview',
+        link: dataEntityOverviewPath(dataEntityId),
+        value: 'overview',
+      },
+      {
+        name: 'Structure',
+        link: datasetStructurePath(dataEntityId),
+        hidden: true,
+        value: 'structure',
+      },
+      {
+        name: 'Lineage',
+        link: dataEntityLineagePath(dataEntityId),
+        value: 'lineage',
+      },
+      {
+        name: 'Test reports',
+        link: dataEntityTestReportPath(dataEntityId),
+        hidden: true,
+        value: 'test-reports',
+      },
+      {
+        name: 'Alerts',
+        link: dataEntityAlertsPath(dataEntityId),
+        value: 'alerts',
+      },
+    ]);
+  }, [dataEntityId]);
+
+  const [selectedTab, setSelectedTab] = React.useState<number>(-1);
+
+  React.useEffect(() => {
+    fetchDataEntityDetails({ dataEntityId });
+  }, [fetchDataEntityDetails, dataEntityId]);
 
   React.useEffect(() => {
     setSelectedTab(
@@ -192,16 +199,16 @@ const DataEntityDetailsView: React.FC<DataEntityDetailsProps> = ({
           ) : null}
         </>
       ) : null}
-      {dataEntityFetchingStatus === 'fetching' ?
-        (<SkeletonWrapper
+      {dataEntityFetchingStatus === 'fetching' ? (
+        <SkeletonWrapper
           renderContent={({ randomSkeletonPercentWidth }) => (
             <DataEntityDetailsSkeleton
               width={randomSkeletonPercentWidth()}
             />
           )}
-        />)
-      : null}
-      {dataEntityFetchingStatus !== 'errorFetching' ?
+        />
+      ) : null}
+      {dataEntityFetchingStatus !== 'errorFetching' ? (
         <Switch>
           <Route
             exact
@@ -238,8 +245,11 @@ const DataEntityDetailsView: React.FC<DataEntityDetailsProps> = ({
             to="/dataentities/:dataEntityId/overview"
           />
         </Switch>
-      : null}
-      <AppErrorPage fetchStatus={dataEntityFetchingStatus} error={dataEntityFetchingError}/>
+      ) : null}
+      <AppErrorPage
+        fetchStatus={dataEntityFetchingStatus}
+        error={dataEntityFetchingError}
+      />
     </div>
   );
 };

--- a/odd-platform-ui/src/components/DataEntityDetails/DataEntityDetailsContainer.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DataEntityDetailsContainer.tsx
@@ -5,6 +5,7 @@ import { RootState } from 'redux/interfaces';
 import {
   getDataEntityDetails,
   getDataEntityIsDataset,
+  getDataEntityIsQualityTest,
   getDataEntityDetailsFetchingStatus,
   getDataEntityDetailsFetchingError,
 } from 'redux/selectors/dataentity.selectors';
@@ -32,8 +33,9 @@ const mapStateToProps = (
   dataEntityId: parseInt(dataEntityId, 10),
   dataEntityDetails: getDataEntityDetails(state, dataEntityId),
   isDataset: getDataEntityIsDataset(state, dataEntityId),
+  isQualityTest: getDataEntityIsQualityTest(state, dataEntityId),
   dataEntityFetchingStatus: getDataEntityDetailsFetchingStatus(state),
-  dataEntityFetchingError: getDataEntityDetailsFetchingError(state)
+  dataEntityFetchingError: getDataEntityDetailsFetchingError(state),
 });
 
 const mapDispatchToProps = {

--- a/odd-platform-ui/src/redux/selectors/dataentity.selectors.ts
+++ b/odd-platform-ui/src/redux/selectors/dataentity.selectors.ts
@@ -2,7 +2,10 @@ import { createSelector } from 'reselect';
 import { get } from 'lodash';
 import { RootState, DataEntitiesState } from 'redux/interfaces';
 import { DataEntityTypeNameEnum } from 'generated-sources';
-import { createFetchingSelector, createErrorSelector } from 'redux/selectors/loader-selectors';
+import {
+  createFetchingSelector,
+  createErrorSelector,
+} from 'redux/selectors/loader-selectors';
 
 const dataEntitiesState = ({
   dataEntities,
@@ -210,5 +213,14 @@ export const getDataEntityIsDataset = createSelector(
   (dataEntities, dataEntityId) =>
     !!dataEntities.byId[dataEntityId]?.types.find(
       type => type.name === DataEntityTypeNameEnum.SET
+    )
+);
+
+export const getDataEntityIsQualityTest = createSelector(
+  dataEntitiesState,
+  getDataEntityId,
+  (dataEntities, dataEntityId) =>
+    !!dataEntities.byId[dataEntityId]?.types.find(
+      type => type.name === DataEntityTypeNameEnum.QUALITY_TEST
     )
 );


### PR DESCRIPTION
Bug fixed.
Removed 'Lineage' tab from data quality entity page.