### PR TITLE
Data quality test details: info about last run and expectations and test runs history page

### DIFF
--- a/odd-platform-ui/src/components/DataEntityDetails/DataEntityDetails.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DataEntityDetails.tsx
@@ -9,6 +9,7 @@ import {
   dataEntityLineagePath,
   dataEntityTestReportPath,
   dataEntityAlertsPath,
+  dataEntityHistoryPath,
 } from 'lib/paths';
 import {
   DataEntityDetails,
@@ -28,6 +29,7 @@ import DataEntityAlertsContainer from 'components/DataEntityDetails/DataEntityAl
 import DataEntityDetailsSkeleton from 'components/DataEntityDetails/DataEntityDetailsSkeleton/DataEntityDetailsSkeleton';
 import SkeletonWrapper from 'components/shared/SkeletonWrapper/SkeletonWrapper';
 import AppErrorPage from 'components/shared/AppErrorPage/AppErrorPage';
+import QualityTestHistoryContainer from 'components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistoryContainer';
 import OverviewContainer from './Overview/OverviewContainer';
 import DatasetStructureContainer from './DatasetStructure/DatasetStructureContainer';
 import LineageContainer from './Lineage/LineageContainer';
@@ -39,6 +41,7 @@ interface DataEntityDetailsProps extends StylesType {
   dataEntityId: number;
   dataEntityDetails: DataEntityDetails;
   isDataset: boolean;
+  isQualityTest: boolean;
   fetchDataEntityDetails: (
     params: DataEntityApiGetDataEntityDetailsRequest
   ) => void;
@@ -52,9 +55,10 @@ const DataEntityDetailsView: React.FC<DataEntityDetailsProps> = ({
   dataEntityId,
   dataEntityDetails,
   isDataset,
+  isQualityTest,
   fetchDataEntityDetails,
   dataEntityFetchingStatus,
-  dataEntityFetchingError
+  dataEntityFetchingError,
 }) => {
   const [tabs, setTabs] = React.useState<AppTabItem[]>([
     {
@@ -80,6 +84,11 @@ const DataEntityDetailsView: React.FC<DataEntityDetailsProps> = ({
       value: 'test-reports',
     },
     {
+      name: 'History',
+      link: dataEntityHistoryPath(dataEntityId),
+      value: 'history',
+    },
+    {
       name: 'Alerts',
       link: dataEntityAlertsPath(dataEntityId),
       value: 'alerts',
@@ -97,8 +106,9 @@ const DataEntityDetailsView: React.FC<DataEntityDetailsProps> = ({
       tabs.map(tab => ({
         ...tab,
         hidden:
-          (tab.value === 'structure' || tab.value === 'test-reports') &&
-          !isDataset,
+          ((tab.value === 'structure' || tab.value === 'test-reports') &&
+            !isDataset) ||
+          (tab.value === 'history' && !isQualityTest),
       }))
     );
   }, [dataEntityDetails]);
@@ -192,16 +202,16 @@ const DataEntityDetailsView: React.FC<DataEntityDetailsProps> = ({
           ) : null}
         </>
       ) : null}
-      {dataEntityFetchingStatus === 'fetching' ?
-        (<SkeletonWrapper
+      {dataEntityFetchingStatus === 'fetching' ? (
+        <SkeletonWrapper
           renderContent={({ randomSkeletonPercentWidth }) => (
             <DataEntityDetailsSkeleton
               width={randomSkeletonPercentWidth()}
             />
           )}
-        />)
-      : null}
-      {dataEntityFetchingStatus !== 'errorFetching' ?
+        />
+      ) : null}
+      {dataEntityFetchingStatus !== 'errorFetching' ? (
         <Switch>
           <Route
             exact
@@ -233,13 +243,21 @@ const DataEntityDetailsView: React.FC<DataEntityDetailsProps> = ({
             path="/dataentities/:dataEntityId/alerts"
             component={DataEntityAlertsContainer}
           />
+          <Route
+            exact
+            path="/dataentities/:dataEntityId/history"
+            component={QualityTestHistoryContainer}
+          />
           <Redirect
             from="/dataentities/:dataEntityId"
             to="/dataentities/:dataEntityId/overview"
           />
         </Switch>
-      : null}
-      <AppErrorPage fetchStatus={dataEntityFetchingStatus} error={dataEntityFetchingError}/>
+      ) : null}
+      <AppErrorPage
+        fetchStatus={dataEntityFetchingStatus}
+        error={dataEntityFetchingError}
+      />
     </div>
   );
 };

--- a/odd-platform-ui/src/components/DataEntityDetails/DataEntityDetailsContainer.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DataEntityDetailsContainer.tsx
@@ -7,6 +7,7 @@ import {
   getDataEntityIsDataset,
   getDataEntityDetailsFetchingStatus,
   getDataEntityDetailsFetchingError,
+  getDataEntityIsQualityTest,
 } from 'redux/selectors/dataentity.selectors';
 import { fetchDataEntityDetails } from 'redux/thunks/dataentities.thunks';
 import { styles } from './DataEntityDetailsStyles';
@@ -32,8 +33,9 @@ const mapStateToProps = (
   dataEntityId: parseInt(dataEntityId, 10),
   dataEntityDetails: getDataEntityDetails(state, dataEntityId),
   isDataset: getDataEntityIsDataset(state, dataEntityId),
+  isQualityTest: getDataEntityIsQualityTest(state, dataEntityId),
   dataEntityFetchingStatus: getDataEntityDetailsFetchingStatus(state),
-  dataEntityFetchingError: getDataEntityDetailsFetchingError(state)
+  dataEntityFetchingError: getDataEntityDetailsFetchingError(state),
 });
 
 const mapDispatchToProps = {

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewQualityTestStats/OverviewQualityTestStats.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewQualityTestStats/OverviewQualityTestStats.tsx
@@ -1,19 +1,25 @@
 import React from 'react';
-import { withStyles, Grid, Typography } from '@material-ui/core';
+import { Grid, Typography, withStyles } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 import {
-  DataEntityTypeNameEnum,
   DataEntityDetails,
+  DataEntityTypeNameEnum,
+  DataQualityTest,
 } from 'generated-sources';
-import { dataEntityDetailsPath } from 'lib/paths';
+import { entries } from 'lodash';
+import { dataEntityDetailsPath, dataEntityHistoryPath } from 'lib/paths';
 import EntityTypeItem from 'components/shared/EntityTypeItem/EntityTypeItem';
 import AppButton from 'components/shared/AppButton/AppButton';
+import cx from 'classnames';
+import { format, formatDistanceStrict } from 'date-fns';
+import LabeledInfoItem from 'components/shared/LabeledInfoItem/LabeledInfoItem';
 import { styles, StylesType } from './OverviewQualityTestStatsStyles';
 
 interface OverviewQualityTestStatsProps extends StylesType {
   suiteName: DataEntityDetails['suiteName'];
   suiteUrl: DataEntityDetails['suiteUrl'];
   datasetsList: DataEntityDetails['datasetsList'];
+  qualityTest: DataQualityTest;
 }
 
 const OverviewQualityTestStats: React.FC<OverviewQualityTestStatsProps> = ({
@@ -21,71 +27,166 @@ const OverviewQualityTestStats: React.FC<OverviewQualityTestStatsProps> = ({
   suiteName,
   suiteUrl,
   datasetsList,
+  qualityTest,
 }) => (
   <Grid container>
-    <Grid item xs={12}>
+    <Grid item>
       <EntityTypeItem
         typeName={DataEntityTypeNameEnum.QUALITY_TEST}
         fullName
         className={classes.typeLabel}
       />
     </Grid>
-    <Grid item container xs={6} className={classes.statsItem}>
-      <Grid item container xs={12} alignItems="baseline">
-        <Typography variant="h2" className={classes.statCount}>
-          {datasetsList?.length || 0}
-        </Typography>
-        <Typography variant="body1" className={classes.statLabel}>
-          datasets
-        </Typography>
+    <Grid container className={classes.statsContainer}>
+      <Grid item className={classes.links}>
+        <Grid item container>
+          <Grid item container alignItems="baseline">
+            <Typography variant="h2" className={classes.linkCount}>
+              {datasetsList?.length || 0}
+            </Typography>
+            <Typography variant="body2" className={classes.statLabel}>
+              datasets
+            </Typography>
+          </Grid>
+          <Grid item>
+            {datasetsList?.map(dataset => (
+              <AppButton
+                key={dataset.id}
+                className={classes.link}
+                size="small"
+                color="tertiary"
+                onClick={() => {}}
+              >
+                <Link to={dataEntityDetailsPath(dataset.id)}>
+                  {dataset.internalName || dataset.externalName}
+                </Link>
+              </AppButton>
+            ))}
+          </Grid>
+        </Grid>
+        <Grid item container className={classes.suites}>
+          <Grid item container>
+            <Typography variant="body2" className={classes.statLabel}>
+              Suite
+            </Typography>
+          </Grid>
+          <Grid item>
+            {suiteUrl ? (
+              <AppButton
+                className={classes.link}
+                size="small"
+                color="tertiary"
+                onClick={() => {}}
+              >
+                <Link to={{ pathname: suiteUrl }} target="_blank">
+                  {suiteName || suiteUrl}
+                </Link>
+              </AppButton>
+            ) : null}
+          </Grid>
+        </Grid>
       </Grid>
-      <Grid
-        item
-        container
-        xs={12}
-        direction="column"
-        alignItems="flex-start"
-      >
-        {datasetsList?.map(dataset => (
-          <AppButton
-            key={dataset.id}
-            className={classes.refItem}
-            size="small"
-            color="tertiary"
-            onClick={() => {}}
-          >
-            <Link to={dataEntityDetailsPath(dataset.id)}>
-              {dataset.internalName || dataset.externalName}
-            </Link>
-          </AppButton>
-        ))}
+      <Grid item className={classes.overview}>
+        <Grid item container xs={12} alignItems="baseline">
+          <Typography variant="body2" className={classes.statLabel}>
+            Overview
+          </Typography>
+        </Grid>
+        <LabeledInfoItem
+          inline
+          label="Last start"
+          labelWidth={4}
+          classes={{
+            value: cx(
+              classes.latestRunStatus,
+              qualityTest && qualityTest.latestRun?.status
+            ),
+          }}
+        >
+          {qualityTest && qualityTest.latestRun?.status}
+        </LabeledInfoItem>
+        <LabeledInfoItem inline label="Date" labelWidth={4}>
+          {qualityTest &&
+            qualityTest.latestRun?.startTime &&
+            format(
+              qualityTest.latestRun?.startTime,
+              'd MMM yyyy, HH:MM a'
+            )}
+        </LabeledInfoItem>
+        <LabeledInfoItem inline label="Duration" labelWidth={4}>
+          {qualityTest &&
+            qualityTest.latestRun?.startTime &&
+            qualityTest.latestRun.endTime &&
+            formatDistanceStrict(
+              qualityTest.latestRun.endTime,
+              qualityTest.latestRun.startTime,
+              {
+                addSuffix: false,
+              }
+            )}
+        </LabeledInfoItem>
+        <LabeledInfoItem inline label="Severity" labelWidth={4}>
+          null
+        </LabeledInfoItem>
+        <Grid container>
+          <Link to={dataEntityHistoryPath(qualityTest.id)}>
+            <AppButton size="small" color="tertiary">
+              History
+            </AppButton>
+          </Link>
+        </Grid>
       </Grid>
-    </Grid>
-    <Grid item container xs={6} className={classes.statsItem}>
-      <Grid item container xs={12} alignItems="baseline">
-        <Typography variant="body1" className={classes.statLabel}>
-          Suite
-        </Typography>
-      </Grid>
-      <Grid
-        item
-        container
-        xs={12}
-        direction="column"
-        alignItems="flex-start"
-      >
-        {suiteUrl ? (
-          <AppButton
-            className={classes.refItem}
-            size="small"
-            color="tertiary"
-            onClick={() => {}}
-          >
-            <Link to={{ pathname: suiteUrl }} target="_blank">
-              {suiteName || suiteUrl}
-            </Link>
-          </AppButton>
-        ) : null}
+      <Grid item container direction="column">
+        <Grid item>
+          <Grid item container xs={12} alignItems="baseline">
+            <Typography variant="body2" className={classes.statLabel}>
+              Parameters
+            </Typography>
+          </Grid>
+          <Grid container className={classes.parameters}>
+            {qualityTest &&
+              entries(qualityTest.expectation).map(([key, value]) => (
+                <LabeledInfoItem
+                  inline
+                  key={key}
+                  label={key}
+                  labelWidth={8}
+                >
+                  {value}
+                </LabeledInfoItem>
+              ))}
+          </Grid>
+        </Grid>
+        <Grid item className={classes.dataQALinks}>
+          <Grid item container xs={12} alignItems="baseline">
+            <Typography variant="body2" className={classes.statLabel}>
+              Links
+            </Typography>
+            <Grid container className={classes.dataQALinksList}>
+              <Grid item container xs={12} wrap="nowrap">
+                {qualityTest &&
+                  qualityTest.linkedUrlList &&
+                  qualityTest?.linkedUrlList.map(link => (
+                    <Typography variant="body1">
+                      {`${link}, `}&nbsp;
+                    </Typography>
+                  ))}
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item className={classes.execution}>
+          <Grid item container xs={12} alignItems="baseline">
+            <Typography variant="body2" className={classes.statLabel}>
+              Execution
+            </Typography>
+            <Grid item xs={12} className={classes.executionInfo}>
+              <Typography variant="body2" color="textSecondary">
+                No information about test execution is available.
+              </Typography>
+            </Grid>
+          </Grid>
+        </Grid>
       </Grid>
     </Grid>
   </Grid>

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewQualityTestStats/OverviewQualityTestStats.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewQualityTestStats/OverviewQualityTestStats.tsx
@@ -99,24 +99,22 @@ const OverviewQualityTestStats: React.FC<OverviewQualityTestStatsProps> = ({
           classes={{
             value: cx(
               classes.latestRunStatus,
-              qualityTest && qualityTest.latestRun?.status
+              qualityTest?.latestRun?.status
             ),
           }}
         >
-          {qualityTest && qualityTest.latestRun?.status}
+          {qualityTest?.latestRun?.status}
         </LabeledInfoItem>
         <LabeledInfoItem inline label="Date" labelWidth={4}>
-          {qualityTest &&
-            qualityTest.latestRun?.startTime &&
+          {qualityTest?.latestRun?.startTime &&
             format(
-              qualityTest.latestRun?.startTime,
+              qualityTest?.latestRun?.startTime,
               'd MMM yyyy, HH:MM a'
             )}
         </LabeledInfoItem>
         <LabeledInfoItem inline label="Duration" labelWidth={4}>
-          {qualityTest &&
-            qualityTest.latestRun?.startTime &&
-            qualityTest.latestRun.endTime &&
+          {qualityTest?.latestRun?.startTime &&
+            qualityTest?.latestRun?.endTime &&
             formatDistanceStrict(
               qualityTest.latestRun.endTime,
               qualityTest.latestRun.startTime,
@@ -129,7 +127,7 @@ const OverviewQualityTestStats: React.FC<OverviewQualityTestStatsProps> = ({
           null
         </LabeledInfoItem>
         <Grid container>
-          <Link to={dataEntityHistoryPath(qualityTest.id)}>
+          <Link to={dataEntityHistoryPath(qualityTest?.id)}>
             <AppButton size="small" color="tertiary">
               History
             </AppButton>
@@ -144,17 +142,11 @@ const OverviewQualityTestStats: React.FC<OverviewQualityTestStatsProps> = ({
             </Typography>
           </Grid>
           <Grid container className={classes.parameters}>
-            {qualityTest &&
-              entries(qualityTest.expectation).map(([key, value]) => (
-                <LabeledInfoItem
-                  inline
-                  key={key}
-                  label={key}
-                  labelWidth={8}
-                >
-                  {value}
-                </LabeledInfoItem>
-              ))}
+            {entries(qualityTest?.expectation).map(([key, value]) => (
+              <LabeledInfoItem inline key={key} label={key} labelWidth={8}>
+                {value}
+              </LabeledInfoItem>
+            ))}
           </Grid>
         </Grid>
         <Grid item className={classes.dataQALinks}>
@@ -164,13 +156,11 @@ const OverviewQualityTestStats: React.FC<OverviewQualityTestStatsProps> = ({
             </Typography>
             <Grid container className={classes.dataQALinksList}>
               <Grid item container xs={12} wrap="nowrap">
-                {qualityTest &&
-                  qualityTest.linkedUrlList &&
-                  qualityTest?.linkedUrlList.map(link => (
-                    <Typography variant="body1">
-                      {`${link}, `}&nbsp;
-                    </Typography>
-                  ))}
+                {qualityTest?.linkedUrlList?.map(link => (
+                  <Typography variant="body1">
+                    {`${link}, `}&nbsp;
+                  </Typography>
+                ))}
               </Grid>
             </Grid>
           </Grid>

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewQualityTestStats/OverviewQualityTestStatsStyles.ts
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewQualityTestStats/OverviewQualityTestStatsStyles.ts
@@ -1,30 +1,70 @@
 import { createStyles, Theme, WithStyles } from '@material-ui/core';
+import { DataQualityTestRunStatusEnum } from 'generated-sources';
+import { statusColor } from 'theme/palette';
 
 export const styles = (theme: Theme) =>
   createStyles({
-    statsItem: {
-      display: 'flex',
-      alignItems: 'flex-start',
-    },
-    statCount: {},
-    statLabel: {
-      color: '#B3BAC5',
-      marginLeft: theme.spacing(0.5),
-      lineHeight: theme.typography.h2.lineHeight,
-    },
-    statValue: {
-      fontWeight: theme.typography.fontWeightBold,
+    statsContainer: {
+      justifyContent: 'space-between',
+      '& > *': {
+        flex: '0 0 278px',
+        marginRight: theme.spacing(4),
+        '&:last-child': { marginRight: 0 },
+      },
     },
     typeLabel: {
       marginLeft: 0,
       marginBottom: theme.spacing(1.25),
     },
-    refItem: {
+    links: {},
+    linkCount: { marginRight: theme.spacing(0.5) },
+    statLabel: {
+      color: '#7A869A',
+      lineHeight: theme.typography.h2.lineHeight,
+    },
+    link: {
       margin: theme.spacing(0.25, 0),
       '&:first-of-type': {
         marginTop: theme.spacing(1),
       },
     },
+    suites: { marginTop: theme.spacing(5) },
+    overview: {
+      '& > *': {
+        marginBottom: theme.spacing(1),
+        marginLeft: theme.spacing(0.5),
+        '&:last-child': { marginLeft: 0 },
+      },
+    },
+    latestRunStatus: {
+      [`&.${DataQualityTestRunStatusEnum.SUCCESS}`]: {
+        color: statusColor.SUCCESS,
+      },
+      [`&.${DataQualityTestRunStatusEnum.FAILED}`]: {
+        color: statusColor.FAILED,
+      },
+      [`&.${DataQualityTestRunStatusEnum.BROKEN}`]: {
+        color: statusColor.BROKEN,
+      },
+      [`&.${DataQualityTestRunStatusEnum.SKIPPED}`]: {
+        color: statusColor.SKIPPED,
+      },
+      [`&.${DataQualityTestRunStatusEnum.ABORTED}`]: {
+        color: statusColor.ABORTED,
+      },
+      [`&.${DataQualityTestRunStatusEnum.UNKNOWN}`]: {
+        color: statusColor.UNKNOWN,
+      },
+    },
+    parameters: {
+      margin: theme.spacing(1, 0, 3, 0),
+    },
+    dataQALinks: {
+      marginBottom: theme.spacing(3),
+    },
+    dataQALinksList: { marginTop: theme.spacing(1) },
+    execution: {},
+    executionInfo: { marginTop: theme.spacing(1) },
   });
 
 export type StylesType = WithStyles<typeof styles>;

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewStats.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewStats.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { withStyles } from '@material-ui/core';
-import {
-  DataEntityTypeNameEnum,
-} from 'generated-sources';
+import { DataEntityTypeNameEnum } from 'generated-sources';
 import { DataEntityDetailsState } from 'redux/interfaces/dataentities';
 import { styles, StylesType } from './OverviewStatsStyles';
 import OverviewDatasetStats from './OverviewDatasetStats/OverviewDatasetStats';
@@ -46,6 +44,7 @@ const OverviewStats: React.FC<OverviewStatsProps> = ({
               suiteName={dataEntityDetails.suiteName}
               suiteUrl={dataEntityDetails.suiteUrl}
               datasetsList={dataEntityDetails.datasetsList}
+              qualityTest={dataEntityDetails}
             />
           );
         default:

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStyles.ts
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStyles.ts
@@ -8,7 +8,7 @@ export const styles = (theme: Theme) =>
       padding: 0,
       '& + $sectionContainer': { marginTop: theme.spacing(2) },
       '& > *': {
-        padding: theme.spacing(2.5, 2),
+        padding: theme.spacing(2, 2),
       },
       '& > * + *': {
         borderTop: '1px solid',

--- a/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunItem/QualityTestRunItem.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunItem/QualityTestRunItem.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Grid, Typography, withStyles } from '@material-ui/core';
+import { DataQualityTestRun } from 'generated-sources';
+import cx from 'classnames';
+import { format, formatDistanceStrict } from 'date-fns';
+import TestRunStatusItem from 'components/shared/TestRunStatusItem/TestRunStatusItem';
+import { styles, StylesType } from './QualityTestRunItemStyles';
+
+interface QualityTestRunItemProps extends StylesType {
+  testRun: DataQualityTestRun;
+}
+
+const QualityTestRunItem: React.FC<QualityTestRunItemProps> = ({
+  classes,
+  testRun,
+}) => (
+  <Grid container className={classes.container}>
+    <Grid item className={cx(classes.col, classes.colmd)}>
+      <Typography variant="body1">
+        {testRun.startTime &&
+          format(testRun.startTime, 'd MMM yyyy, HH:MM a')}
+      </Typography>
+    </Grid>
+    <Grid item className={cx(classes.col, classes.colmd)}>
+      <TestRunStatusItem typeName={testRun.status} />
+    </Grid>
+    <Grid item className={cx(classes.col, classes.collg)}>
+      <Typography variant="body1">{testRun.statusReason}</Typography>
+    </Grid>
+    <Grid item className={cx(classes.col, classes.colsm)}>
+      <Typography variant="body1">
+        {testRun.endTime &&
+          testRun.startTime &&
+          formatDistanceStrict(testRun.endTime, testRun.startTime, {
+            addSuffix: false,
+          })}
+      </Typography>
+    </Grid>
+  </Grid>
+);
+
+export default withStyles(styles)(QualityTestRunItem);

--- a/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunItem/QualityTestRunItemStyles.ts
+++ b/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunItem/QualityTestRunItemStyles.ts
@@ -1,0 +1,14 @@
+import { createStyles, Theme, WithStyles } from '@material-ui/core';
+import { colWidthStyles } from '../QualityTestRunsHistoryStyles';
+
+export const styles = (theme: Theme) =>
+  createStyles({
+    container: {
+      flexWrap: 'nowrap',
+      padding: theme.spacing(1.5, 0),
+      borderBottom: '1px solid #EBECF0',
+    },
+    ...colWidthStyles,
+  });
+
+export type StylesType = WithStyles<typeof styles>;

--- a/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistory.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistory.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {
+  DataQualityApiGetRunsRequest,
+  DataQualityTestRun,
+} from 'generated-sources';
+import cx from 'classnames';
+import { Grid, Typography } from '@material-ui/core';
+import { StylesType } from 'components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistoryStyles';
+import EmptyContentPlaceholder from 'components/shared/EmptyContentPlaceholder/EmptyContentPlaceholder';
+import QualityTestRunItem from 'components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunItem/QualityTestRunItem';
+
+interface QualityTestHistoryProps extends StylesType {
+  dataqatestId: number;
+  testRuns: DataQualityTestRun[];
+  isTestRunsFetching: boolean;
+  fetchDataSetQualityTestRuns: (
+    params: DataQualityApiGetRunsRequest
+  ) => void;
+}
+
+const QualityTestRunsHistory: React.FC<QualityTestHistoryProps> = ({
+  classes,
+  dataqatestId,
+  testRuns,
+  isTestRunsFetching,
+  fetchDataSetQualityTestRuns,
+}) => {
+  React.useEffect(() => {
+    fetchDataSetQualityTestRuns({ dataqatestId });
+  }, [fetchDataSetQualityTestRuns, dataqatestId]);
+
+  return (
+    <Grid container className={classes.container}>
+      <Grid container className={classes.runsTableHeader} wrap="nowrap">
+        <Grid item className={cx(classes.col, classes.colmd)}>
+          <Typography variant="caption">Start time</Typography>
+        </Grid>
+        <Grid item className={cx(classes.col, classes.colmd)}>
+          <Typography variant="caption">Status</Typography>
+        </Grid>
+        <Grid item className={cx(classes.col, classes.collg)}>
+          <Typography variant="caption">Status reason</Typography>
+        </Grid>
+        <Grid item className={cx(classes.col, classes.colsm)}>
+          <Typography variant="caption">Duration</Typography>
+        </Grid>
+      </Grid>
+      <Grid container>
+        {testRuns &&
+          testRuns.map(testRun => (
+            <QualityTestRunItem key={testRun.id} testRun={testRun} />
+          ))}
+      </Grid>
+      {!isTestRunsFetching && !testRuns?.length ? (
+        <EmptyContentPlaceholder />
+      ) : null}
+    </Grid>
+  );
+};
+
+export default QualityTestRunsHistory;

--- a/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistory.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistory.tsx
@@ -11,8 +11,8 @@ import QualityTestRunItem from 'components/DataEntityDetails/QualityTestRunsHist
 
 interface QualityTestHistoryProps extends StylesType {
   dataqatestId: number;
-  testRuns: DataQualityTestRun[];
-  isTestRunsFetching: boolean;
+  testRunsList: DataQualityTestRun[];
+  isTestRunsListFetching: boolean;
   fetchDataSetQualityTestRuns: (
     params: DataQualityApiGetRunsRequest
   ) => void;
@@ -21,8 +21,8 @@ interface QualityTestHistoryProps extends StylesType {
 const QualityTestRunsHistory: React.FC<QualityTestHistoryProps> = ({
   classes,
   dataqatestId,
-  testRuns,
-  isTestRunsFetching,
+  testRunsList,
+  isTestRunsListFetching,
   fetchDataSetQualityTestRuns,
 }) => {
   React.useEffect(() => {
@@ -46,12 +46,11 @@ const QualityTestRunsHistory: React.FC<QualityTestHistoryProps> = ({
         </Grid>
       </Grid>
       <Grid container>
-        {testRuns &&
-          testRuns.map(testRun => (
-            <QualityTestRunItem key={testRun.id} testRun={testRun} />
-          ))}
+        {testRunsList?.map(testRun => (
+          <QualityTestRunItem key={testRun.id} testRun={testRun} />
+        ))}
       </Grid>
-      {!isTestRunsFetching && !testRuns?.length ? (
+      {!isTestRunsListFetching && !testRunsList?.length ? (
         <EmptyContentPlaceholder />
       ) : null}
     </Grid>

--- a/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistoryContainer.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistoryContainer.tsx
@@ -25,8 +25,8 @@ const mapStateToProps = (
   }: OwnProps
 ) => ({
   dataqatestId: parseInt(dataEntityId, 10),
-  testRuns: getQualityTestRunsList(state, dataEntityId),
-  isTestRunsFetching: getDatasetTestRunsFetching(state),
+  testRunsList: getQualityTestRunsList(state, dataEntityId),
+  isTestRunsListFetching: getDatasetTestRunsFetching(state),
 });
 
 const mapDispatchToProps = {

--- a/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistoryContainer.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistoryContainer.tsx
@@ -1,0 +1,39 @@
+import { withStyles } from '@material-ui/core';
+import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
+import { RootState } from 'redux/interfaces';
+import { fetchDataSetQualityTestRuns } from 'redux/thunks';
+import {
+  getDatasetTestRunsFetching,
+  getQualityTestRunsList,
+} from 'redux/selectors/dataQualityTest.selectors';
+import { styles } from 'components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistoryStyles';
+import QualityTestRunsHistory from 'components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistory';
+
+interface RouteProps {
+  dataEntityId: string;
+}
+
+type OwnProps = RouteComponentProps<RouteProps>;
+
+const mapStateToProps = (
+  state: RootState,
+  {
+    match: {
+      params: { dataEntityId },
+    },
+  }: OwnProps
+) => ({
+  dataqatestId: parseInt(dataEntityId, 10),
+  testRuns: getQualityTestRunsList(state, dataEntityId),
+  isTestRunsFetching: getDatasetTestRunsFetching(state),
+});
+
+const mapDispatchToProps = {
+  fetchDataSetQualityTestRuns,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withStyles(styles)(QualityTestRunsHistory));

--- a/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistoryStyles.ts
+++ b/odd-platform-ui/src/components/DataEntityDetails/QualityTestRunsHistory/QualityTestRunsHistoryStyles.ts
@@ -1,0 +1,39 @@
+import { createStyles, Theme, WithStyles } from '@material-ui/core';
+
+export const colWidthStyles = {
+  colsm: {
+    flex: '1 0 3%',
+  },
+  colmd: {
+    flex: '2 0 5%',
+  },
+  collg: {
+    flex: '5 0 18%',
+  },
+  col: {
+    display: 'flex',
+    alignItems: 'center',
+    overflow: 'hidden',
+    paddingRight: '8px',
+    paddingLeft: '8px',
+    '&:last-of-type': {
+      paddingRight: 0,
+    },
+  },
+};
+
+export const styles = (theme: Theme) =>
+  createStyles({
+    container: {},
+    resultsTable: {},
+    runsTableHeader: {
+      color: '#B3BAC5',
+      '& > *': {
+        borderBottom: '1px solid',
+        borderBottomColor: '#EBECF0',
+      },
+    },
+    ...colWidthStyles,
+  });
+
+export type StylesType = WithStyles<typeof styles>;

--- a/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReport.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReport.tsx
@@ -85,7 +85,6 @@ const TestReport: React.FC<TestReportProps> = ({
                   }}
                   count={datasetTestReport?.successTotal}
                   typeName={DataQualityTestRunStatusEnum.SUCCESS}
-                  size="large"
                 />
                 <TestRunStatusItem
                   classes={{
@@ -93,7 +92,6 @@ const TestReport: React.FC<TestReportProps> = ({
                   }}
                   count={datasetTestReport?.failedTotal}
                   typeName={DataQualityTestRunStatusEnum.FAILED}
-                  size="large"
                 />
                 <TestRunStatusItem
                   classes={{
@@ -101,7 +99,6 @@ const TestReport: React.FC<TestReportProps> = ({
                   }}
                   count={datasetTestReport?.brokenTotal}
                   typeName={DataQualityTestRunStatusEnum.BROKEN}
-                  size="large"
                 />
                 <TestRunStatusItem
                   classes={{
@@ -109,7 +106,6 @@ const TestReport: React.FC<TestReportProps> = ({
                   }}
                   count={datasetTestReport?.abortedTotal}
                   typeName={DataQualityTestRunStatusEnum.ABORTED}
-                  size="large"
                 />
                 <TestRunStatusItem
                   classes={{
@@ -117,7 +113,6 @@ const TestReport: React.FC<TestReportProps> = ({
                   }}
                   count={datasetTestReport?.skippedTotal}
                   typeName={DataQualityTestRunStatusEnum.SKIPPED}
-                  size="large"
                 />
                 <TestRunStatusItem
                   classes={{
@@ -125,7 +120,6 @@ const TestReport: React.FC<TestReportProps> = ({
                   }}
                   count={datasetTestReport?.unknownTotal}
                   typeName={DataQualityTestRunStatusEnum.UNKNOWN}
-                  size="large"
                 />
               </Grid>
               <Grid container item className={classes.testCount}>

--- a/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReportDetails/TestReportDetailsHistory/TestReportDetailsHistory.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReportDetails/TestReportDetailsHistory/TestReportDetailsHistory.tsx
@@ -70,10 +70,7 @@ const TestReportDetailsHistory: React.FC<TestReportDetailsHistoryProps> = ({
             wrap="nowrap"
           >
             {qualityTestRun.status && (
-              <TestRunStatusItem
-                typeName={qualityTestRun.status}
-                size="large"
-              />
+              <TestRunStatusItem typeName={qualityTestRun.status} />
             )}
             <Typography
               variant="subtitle1"

--- a/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReportDetails/TestReportDetailsOverview/TestReportDetailsOverview.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReportDetails/TestReportDetailsOverview/TestReportDetailsOverview.tsx
@@ -58,7 +58,7 @@ const TestReportDetailsOverview: React.FC<TestReportDetailsOverviewProps> = ({
                     qualityTest?.latestRun.endTime,
                     qualityTest?.latestRun.startTime,
                     {
-                      addSuffix: true,
+                      addSuffix: false,
                     }
                   )}
               </Typography>

--- a/odd-platform-ui/src/components/shared/TestRunStatusItem/TestRunStatusItem.tsx
+++ b/odd-platform-ui/src/components/shared/TestRunStatusItem/TestRunStatusItem.tsx
@@ -10,7 +10,7 @@ import { DataQualityTestRunStatusEnum } from 'generated-sources';
 interface TestRunStatusItemProps extends StylesType {
   className?: string;
   count?: number;
-  typeName: DataQualityTestRunStatusEnum | undefined;
+  typeName?: DataQualityTestRunStatusEnum;
   size?: 'large' | 'small';
 }
 
@@ -30,7 +30,7 @@ const TestRunStatusItem: React.FC<TestRunStatusItemProps> = ({
       <>
         <span className={classes.count}>{count}</span>
         <span className={cx(classes.filledContainer, typeName)}>
-          {typeName && typeName.toLowerCase()}
+          {typeName?.toLowerCase()}
         </span>
       </>
     )}

--- a/odd-platform-ui/src/components/shared/TestRunStatusItem/TestRunStatusItem.tsx
+++ b/odd-platform-ui/src/components/shared/TestRunStatusItem/TestRunStatusItem.tsx
@@ -10,13 +10,13 @@ import { DataQualityTestRunStatusEnum } from 'generated-sources';
 interface TestRunStatusItemProps extends StylesType {
   className?: string;
   count?: number;
-  typeName: DataQualityTestRunStatusEnum;
+  typeName: DataQualityTestRunStatusEnum | undefined;
   size?: 'large' | 'small';
 }
 
 const TestRunStatusItem: React.FC<TestRunStatusItemProps> = ({
   className,
-  size = 'small',
+  size = 'large',
   typeName,
   count,
   classes,
@@ -30,7 +30,7 @@ const TestRunStatusItem: React.FC<TestRunStatusItemProps> = ({
       <>
         <span className={classes.count}>{count}</span>
         <span className={cx(classes.filledContainer, typeName)}>
-          {typeName.toLowerCase()}
+          {typeName && typeName.toLowerCase()}
         </span>
       </>
     )}

--- a/odd-platform-ui/src/lib/paths.ts
+++ b/odd-platform-ui/src/lib/paths.ts
@@ -28,6 +28,9 @@ export const dataEntityTestPath = (datasetId: number, testId: number) =>
 export const dataEntityAlertsPath = (datasetId: number) =>
   `${dataEntityDetailsPath(datasetId)}/alerts`;
 
+export const dataEntityHistoryPath = (datasetId: number) =>
+  `${dataEntityDetailsPath(datasetId)}/history`;
+
 // Test reports details
 export const testReportDetailsOverviewPath = (
   datasetId: number,

--- a/odd-platform-ui/src/redux/selectors/dataentity.selectors.ts
+++ b/odd-platform-ui/src/redux/selectors/dataentity.selectors.ts
@@ -2,7 +2,10 @@ import { createSelector } from 'reselect';
 import { get } from 'lodash';
 import { RootState, DataEntitiesState } from 'redux/interfaces';
 import { DataEntityTypeNameEnum } from 'generated-sources';
-import { createFetchingSelector, createErrorSelector } from 'redux/selectors/loader-selectors';
+import {
+  createFetchingSelector,
+  createErrorSelector,
+} from 'redux/selectors/loader-selectors';
 
 const dataEntitiesState = ({
   dataEntities,
@@ -210,5 +213,14 @@ export const getDataEntityIsDataset = createSelector(
   (dataEntities, dataEntityId) =>
     !!dataEntities.byId[dataEntityId]?.types.find(
       type => type.name === DataEntityTypeNameEnum.SET
+    )
+);
+
+export const getDataEntityIsQualityTest = createSelector(
+  dataEntitiesState,
+  getDataEntityId,
+  (dataEntities, dataEntityId) =>
+    !!dataEntities.byId[dataEntityId]?.types.find(
+      type => type.name === DataEntityTypeNameEnum.QUALITY_TEST
     )
 );


### PR DESCRIPTION
Added latest test run info to the overview of Quality Test page.
Added History page with test runs info.
<img width="925" alt="Screenshot 2021-09-07 at 18 29 25" src="https://user-images.githubusercontent.com/59020701/132371688-a520f8ef-452e-4639-aed9-8b2547515a9a.png">
<img width="1788" alt="Screenshot 2021-09-07 at 18 28 59" src="https://user-images.githubusercontent.com/59020701/132371700-a72ca78a-e899-4a74-bfc3-3de107152cea.png">
