### PR TITLE
Feature: Data Entity card preview on the search page

### DIFF
--- a/odd-platform-ui/src/components/Alerts/AlertsList/AlertItem/AlertItem.tsx
+++ b/odd-platform-ui/src/components/Alerts/AlertsList/AlertItem/AlertItem.tsx
@@ -40,7 +40,7 @@ const AlertItem: React.FC<AlertItemProps> = ({
           }
         >
           <AppTooltip
-            renderTitle={() =>
+            renderContent={() =>
               alert.dataEntity?.internalName ||
               alert.dataEntity?.externalName
             }
@@ -95,7 +95,7 @@ const AlertItem: React.FC<AlertItemProps> = ({
     >
       <AppTooltip
         control="byClick"
-        renderTitle={() => (
+        renderContent={() => (
           <MenuItem onClick={alertStatusHandler}>
             {alert.status === 'OPEN' ? 'Resolve' : 'Reopen'} alert
           </MenuItem>

--- a/odd-platform-ui/src/components/Alerts/AlertsList/AlertItem/AlertItem.tsx
+++ b/odd-platform-ui/src/components/Alerts/AlertsList/AlertItem/AlertItem.tsx
@@ -40,7 +40,7 @@ const AlertItem: React.FC<AlertItemProps> = ({
           }
         >
           <AppTooltip
-            title={
+            renderTitle={() =>
               alert.dataEntity?.internalName ||
               alert.dataEntity?.externalName
             }
@@ -95,11 +95,11 @@ const AlertItem: React.FC<AlertItemProps> = ({
     >
       <AppTooltip
         control="byClick"
-        title={
+        renderTitle={() => (
           <MenuItem onClick={alertStatusHandler}>
             {alert.status === 'OPEN' ? 'Resolve' : 'Reopen'} alert
           </MenuItem>
-        }
+        )}
       >
         <AppIconButton
           size="medium"

--- a/odd-platform-ui/src/components/DataEntityDetails/DataEntityAlerts/DataEntityAlertItem/DataEntityAlertItem.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DataEntityAlerts/DataEntityAlertItem/DataEntityAlertItem.tsx
@@ -29,7 +29,7 @@ const DataEntityAlertItem: React.FC<DataEntityAlertItemProps> = ({
     </Grid>
     <Grid item className={cx(classes.col, classes.colType)}>
       <AppTooltip
-        renderTitle={() => lowerCase(alert.type)}
+        renderContent={() => lowerCase(alert.type)}
         offset={{ right: 80 }}
       >
         <Typography variant="body1" title={alert.type} noWrap>
@@ -63,7 +63,7 @@ const DataEntityAlertItem: React.FC<DataEntityAlertItemProps> = ({
     >
       <AppTooltip
         control="byClick"
-        renderTitle={() => (
+        renderContent={() => (
           <MenuItem onClick={alertStatusHandler}>
             {alert.status === 'OPEN' ? 'Resolve' : 'Reopen'} alert
           </MenuItem>

--- a/odd-platform-ui/src/components/DataEntityDetails/DataEntityAlerts/DataEntityAlertItem/DataEntityAlertItem.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DataEntityAlerts/DataEntityAlertItem/DataEntityAlertItem.tsx
@@ -28,7 +28,10 @@ const DataEntityAlertItem: React.FC<DataEntityAlertItemProps> = ({
       </Typography>
     </Grid>
     <Grid item className={cx(classes.col, classes.colType)}>
-      <AppTooltip title={lowerCase(alert.type)} offset={{ right: 80 }}>
+      <AppTooltip
+        renderTitle={() => lowerCase(alert.type)}
+        offset={{ right: 80 }}
+      >
         <Typography variant="body1" title={alert.type} noWrap>
           {lowerCase(alert.type)}
         </Typography>
@@ -60,11 +63,11 @@ const DataEntityAlertItem: React.FC<DataEntityAlertItemProps> = ({
     >
       <AppTooltip
         control="byClick"
-        title={
+        renderTitle={() => (
           <MenuItem onClick={alertStatusHandler}>
             {alert.status === 'OPEN' ? 'Resolve' : 'Reopen'} alert
           </MenuItem>
-        }
+        )}
       >
         <AppIconButton
           size="medium"

--- a/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureTable/DatasetStructureItem/DatasetStructureItem.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureTable/DatasetStructureItem/DatasetStructureItem.tsx
@@ -149,7 +149,7 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
               </Grid>
               <Grid item container>
                 <Grid item xs={12} className={classes.nameContainer}>
-                  <AppTooltip renderTitle={() => datasetField.name}>
+                  <AppTooltip renderContent={() => datasetField.name}>
                     <Typography noWrap>
                       {(datasetField.isKey && 'Key') ||
                         (datasetField.isValue && 'Value') ||
@@ -172,7 +172,7 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
                   className={classes.descriptionContainer}
                 >
                   <AppTooltip
-                    renderTitle={() => datasetField.internalDescription}
+                    renderContent={() => datasetField.internalDescription}
                     offset={{ right: 160 }}
                   >
                     <Typography
@@ -183,7 +183,7 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
                     </Typography>
                   </AppTooltip>
                   <AppTooltip
-                    renderTitle={() => datasetField.externalDescription}
+                    renderContent={() => datasetField.externalDescription}
                   >
                     <Typography
                       className={classes.externalDescription}
@@ -210,7 +210,7 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
               <div className={classes.optionsBtn}>
                 <AppTooltip
                   control="byClick"
-                  renderTitle={() => (
+                  renderContent={() => (
                     <>
                       <LabelsEditFormContainer
                         datasetFieldId={datasetField.id}
@@ -235,7 +235,7 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
               />
               <div>
                 <AppTooltip
-                  renderTitle={() =>
+                  renderContent={() =>
                     `Logical type: ${datasetField.type.logicalType}`
                   }
                   type="dark"

--- a/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureTable/DatasetStructureItem/DatasetStructureItem.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureTable/DatasetStructureItem/DatasetStructureItem.tsx
@@ -149,7 +149,7 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
               </Grid>
               <Grid item container>
                 <Grid item xs={12} className={classes.nameContainer}>
-                  <AppTooltip title={datasetField.name}>
+                  <AppTooltip renderTitle={() => datasetField.name}>
                     <Typography noWrap>
                       {(datasetField.isKey && 'Key') ||
                         (datasetField.isValue && 'Value') ||
@@ -172,7 +172,7 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
                   className={classes.descriptionContainer}
                 >
                   <AppTooltip
-                    title={datasetField.internalDescription}
+                    renderTitle={() => datasetField.internalDescription}
                     offset={{ right: 160 }}
                   >
                     <Typography
@@ -182,7 +182,9 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
                       {datasetField.internalDescription}
                     </Typography>
                   </AppTooltip>
-                  <AppTooltip title={datasetField.externalDescription}>
+                  <AppTooltip
+                    renderTitle={() => datasetField.externalDescription}
+                  >
                     <Typography
                       className={classes.externalDescription}
                       noWrap
@@ -208,7 +210,7 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
               <div className={classes.optionsBtn}>
                 <AppTooltip
                   control="byClick"
-                  title={
+                  renderTitle={() => (
                     <>
                       <LabelsEditFormContainer
                         datasetFieldId={datasetField.id}
@@ -219,7 +221,7 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
                         btnCreateEl={<MenuItem>Edit Description</MenuItem>}
                       />
                     </>
-                  }
+                  )}
                 >
                   <AppIconButton
                     size="medium"
@@ -233,7 +235,9 @@ const DatasetStructureItem: React.FC<DatasetStructureItemProps> = ({
               />
               <div>
                 <AppTooltip
-                  title={`Logical type: ${datasetField.type.logicalType}`}
+                  renderTitle={() =>
+                    `Logical type: ${datasetField.type.logicalType}`
+                  }
                   type="dark"
                 >
                   <InformationIcon

--- a/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReportDetails/TestReportDetailsOverview/TestReportDetailsOverview.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReportDetails/TestReportDetailsOverview/TestReportDetailsOverview.tsx
@@ -86,7 +86,7 @@ const TestReportDetailsOverview: React.FC<TestReportDetailsOverviewProps> = ({
                 value && (
                   <Grid key={key} container>
                     <Grid item xs={4} className={classes.paramName}>
-                      <AppTooltip title={key}>
+                      <AppTooltip renderTitle={() => key}>
                         <Typography
                           variant="body1"
                           color="textSecondary"
@@ -97,7 +97,7 @@ const TestReportDetailsOverview: React.FC<TestReportDetailsOverviewProps> = ({
                       </AppTooltip>
                     </Grid>
                     <Grid item xs={8}>
-                      <AppTooltip title={value}>
+                      <AppTooltip renderTitle={() => value}>
                         <Typography variant="body1" noWrap>
                           {value}
                         </Typography>

--- a/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReportDetails/TestReportDetailsOverview/TestReportDetailsOverview.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/TestReport/TestReportDetails/TestReportDetailsOverview/TestReportDetailsOverview.tsx
@@ -86,7 +86,7 @@ const TestReportDetailsOverview: React.FC<TestReportDetailsOverviewProps> = ({
                 value && (
                   <Grid key={key} container>
                     <Grid item xs={4} className={classes.paramName}>
-                      <AppTooltip renderTitle={() => key}>
+                      <AppTooltip renderContent={() => key}>
                         <Typography
                           variant="body1"
                           color="textSecondary"
@@ -97,7 +97,7 @@ const TestReportDetailsOverview: React.FC<TestReportDetailsOverviewProps> = ({
                       </AppTooltip>
                     </Grid>
                     <Grid item xs={8}>
-                      <AppTooltip renderTitle={() => value}>
+                      <AppTooltip renderContent={() => value}>
                         <Typography variant="body1" noWrap>
                           {value}
                         </Typography>

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
@@ -55,7 +55,7 @@ const ResultItem: React.FC<ResultItemProps> = ({
             <AppTooltip
               maxWidth={285}
               sx={{ ml: 1.25 }}
-              renderTitle={({ isTooltipShown }) => (
+              renderContent={({ isTooltipShown }) => (
                 <ResultItemPreviewContainer
                   dataEntityId={searchResult.id}
                   fetchData={isTooltipShown}

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { Grid, Typography } from '@mui/material';
 import { format, formatDistanceToNowStrict } from 'date-fns';
-import {
-  DataEntity,
-  DataEntityApiGetDataEntityDetailsRequest,
-  DataEntityDetails,
-  DataEntityTypeNameEnum,
-  MetadataFieldValue,
-} from 'generated-sources';
+import { DataEntity, DataEntityTypeNameEnum } from 'generated-sources';
 import { SearchTotalsByName, SearchType } from 'redux/interfaces/search';
 import EntityTypeItem from 'components/shared/EntityTypeItem/EntityTypeItem';
 import { dataEntityDetailsPath } from 'lib/paths';
@@ -15,43 +9,22 @@ import ResultItemTruncatedCell from 'components/Search/Results/ResultItem/Result
 import InformationIcon from 'components/shared/Icons/InformationIcon';
 import AppTooltip from 'components/shared/AppTooltip/AppTooltip';
 import { ColContainer } from 'components/Search/Results/ResultsStyles';
-import ResultItemPreview from 'components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreview';
+import ResultItemPreviewContainer from 'components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreviewContainer';
 import { Container, ItemLink } from './ResultItemStyles';
 
 interface ResultItemProps {
+  dataEntityId: number;
   searchType?: SearchType;
   totals: SearchTotalsByName;
   searchResult: DataEntity;
-  dataEntityDetails: DataEntityDetails;
-  fetchDataEntityDetails: (
-    params: DataEntityApiGetDataEntityDetailsRequest
-  ) => void;
-  isDataEntityLoading: boolean;
-  predefinedMetadata: MetadataFieldValue[];
-  customMetadata: MetadataFieldValue[];
 }
 
 const ResultItem: React.FC<ResultItemProps> = ({
   searchResult,
   searchType,
   totals,
-  dataEntityDetails,
-  fetchDataEntityDetails,
-  isDataEntityLoading,
-  predefinedMetadata,
-  customMetadata,
 }) => {
   const detailsLink = dataEntityDetailsPath(searchResult.id);
-
-  const fetchDetails = React.useCallback(
-    () => fetchDataEntityDetails({ dataEntityId: searchResult.id }),
-    [searchResult.id]
-  );
-
-  const resultItemPreviewHandler = () => {
-    if (!dataEntityDetails) return fetchDetails();
-    return null;
-  };
 
   return (
     <ItemLink to={detailsLink}>
@@ -82,16 +55,13 @@ const ResultItem: React.FC<ResultItemProps> = ({
             <AppTooltip
               maxWidth={285}
               sx={{ ml: 1.25 }}
-              title={
-                <ResultItemPreview
-                  dataEntityDetails={dataEntityDetails}
-                  isDataEntityLoading={isDataEntityLoading}
-                  predefinedMetadata={predefinedMetadata}
-                  customMetadata={customMetadata}
+              renderTitle={({ isTooltipShown }) => (
+                <ResultItemPreviewContainer
+                  dataEntityId={searchResult.id}
+                  fetchData={isTooltipShown}
                 />
-              }
+              )}
               offset={{ right: 140 }}
-              onMouseEnterCallback={resultItemPreviewHandler}
             >
               <InformationIcon
                 sx={{ display: 'flex', alignItems: 'center' }}

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
@@ -1,48 +1,110 @@
 import React from 'react';
 import { Grid, Typography } from '@mui/material';
-import withStyles from '@mui/styles/withStyles';
 import { format, formatDistanceToNowStrict } from 'date-fns';
-import { Link } from 'react-router-dom';
-import cx from 'classnames';
-import { DataEntity, DataEntityTypeNameEnum } from 'generated-sources';
+import {
+  DataEntity,
+  DataEntityApiGetDataEntityDetailsRequest,
+  DataEntityDetails,
+  DataEntityTypeNameEnum,
+  MetadataFieldValue,
+} from 'generated-sources';
 import { SearchTotalsByName, SearchType } from 'redux/interfaces/search';
 import EntityTypeItem from 'components/shared/EntityTypeItem/EntityTypeItem';
 import { dataEntityDetailsPath } from 'lib/paths';
 import ResultItemTruncatedCell from 'components/Search/Results/ResultItem/ResultItemTruncatedCell/ResultItemTruncatedCell';
-import { styles, StylesType } from './ResultItemStyles';
+import InformationIcon from 'components/shared/Icons/InformationIcon';
+import AppTooltip from 'components/shared/AppTooltip/AppTooltip';
+import { ColContainer } from 'components/Search/Results/ResultsStyles';
+import ResultItemPreview from 'components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreview';
+import { Container, ItemLink } from './ResultItemStyles';
 
-interface ResultItemProps extends StylesType {
+interface ResultItemProps {
   searchType?: SearchType;
   totals: SearchTotalsByName;
   searchResult: DataEntity;
+  dataEntityDetails: DataEntityDetails;
+  fetchDataEntityDetails: (
+    params: DataEntityApiGetDataEntityDetailsRequest
+  ) => void;
+  isDataEntityLoading: boolean;
+  predefinedMetadata: MetadataFieldValue[];
+  customMetadata: MetadataFieldValue[];
 }
 
 const ResultItem: React.FC<ResultItemProps> = ({
-  classes,
   searchResult,
   searchType,
   totals,
+  dataEntityDetails,
+  fetchDataEntityDetails,
+  isDataEntityLoading,
+  predefinedMetadata,
+  customMetadata,
 }) => {
   const detailsLink = dataEntityDetailsPath(searchResult.id);
 
+  const fetchDetails = React.useCallback(
+    () => fetchDataEntityDetails({ dataEntityId: searchResult.id }),
+    [searchResult.id]
+  );
+
+  const resultItemPreviewHandler = () => {
+    if (!dataEntityDetails) return fetchDetails();
+    return null;
+  };
+
   return (
-    <Link to={detailsLink} className={classes.itemLink}>
-      <Grid container className={classes.container} wrap="nowrap">
-        <Grid
+    <ItemLink to={detailsLink}>
+      <Container container>
+        <ColContainer
+          $colType="collg"
           item
           container
           justifyContent="space-between"
           wrap="nowrap"
-          className={cx(classes.col, classes.collg)}
         >
-          <Typography
-            variant="body1"
-            noWrap
-            title={searchResult.internalName || searchResult.externalName}
+          <ColContainer
+            $colType="col"
+            container
+            item
+            justifyContent="flex-start"
+            wrap="nowrap"
           >
-            {searchResult.internalName || searchResult.externalName}
-          </Typography>
-          <div>
+            <Typography
+              variant="body1"
+              noWrap
+              title={
+                searchResult.internalName || searchResult.externalName
+              }
+            >
+              {searchResult.internalName || searchResult.externalName}
+            </Typography>
+            <AppTooltip
+              maxWidth={285}
+              sx={{ ml: 1.25 }}
+              title={
+                <ResultItemPreview
+                  dataEntityDetails={dataEntityDetails}
+                  isDataEntityLoading={isDataEntityLoading}
+                  predefinedMetadata={predefinedMetadata}
+                  customMetadata={customMetadata}
+                />
+              }
+              offset={{ right: 140 }}
+              onMouseEnterCallback={resultItemPreviewHandler}
+            >
+              <InformationIcon
+                sx={{ display: 'flex', alignItems: 'center' }}
+              />
+            </AppTooltip>
+          </ColContainer>
+          <Grid
+            container
+            item
+            justifyContent="flex-end"
+            wrap="nowrap"
+            flexBasis={0}
+          >
             {!searchType ||
               (typeof searchType === 'string' &&
                 searchResult.types?.map(type => (
@@ -52,82 +114,72 @@ const ResultItem: React.FC<ResultItemProps> = ({
                     typeName={type.name}
                   />
                 )))}
-          </div>
-        </Grid>
+          </Grid>
+        </ColContainer>
         {searchType &&
         searchType === totals[DataEntityTypeNameEnum.SET]?.id ? (
           <>
-            <Grid item className={cx(classes.col, classes.colxs)}>
+            <ColContainer item $colType="colxs">
               <Typography variant="body1" noWrap>
                 {searchResult.stats?.consumersCount}
               </Typography>
-            </Grid>
-            <Grid item className={cx(classes.col, classes.colxs)}>
+            </ColContainer>
+            <ColContainer item $colType="colxs">
               <Typography variant="body1" noWrap>
                 {searchResult.stats?.rowsCount}
               </Typography>
-            </Grid>
-            <Grid item className={cx(classes.col, classes.colxs)}>
+            </ColContainer>
+            <ColContainer item $colType="colxs">
               <Typography variant="body1" noWrap>
                 {searchResult.stats?.fieldsCount}
               </Typography>
-            </Grid>
+            </ColContainer>
           </>
         ) : null}
         {searchType &&
         searchType === totals[DataEntityTypeNameEnum.TRANSFORMER]?.id ? (
           <>
-            <Grid
-              item
-              container
-              wrap="wrap"
-              className={cx(classes.col, classes.collg)}
-            >
+            <ColContainer $colType="collg" item container wrap="wrap">
               <ResultItemTruncatedCell
                 searchResult={searchResult}
                 truncatedCellType="sourceList"
               />
-            </Grid>
-            <Grid item className={cx(classes.col, classes.collg)}>
+            </ColContainer>
+            <ColContainer item $colType="collg">
               <ResultItemTruncatedCell
                 searchResult={searchResult}
                 truncatedCellType="targetList"
               />
-            </Grid>
+            </ColContainer>
           </>
         ) : null}
         {searchType &&
         searchType === totals[DataEntityTypeNameEnum.CONSUMER]?.id ? (
-          <Grid item className={cx(classes.col, classes.collg)}>
+          <ColContainer item $colType="collg">
             <ResultItemTruncatedCell
               searchResult={searchResult}
               truncatedCellType="inputList"
             />
-          </Grid>
+          </ColContainer>
         ) : null}
         {searchType &&
         searchType === totals[DataEntityTypeNameEnum.QUALITY_TEST]?.id ? (
           <>
-            <Grid
-              item
-              container
-              wrap="wrap"
-              className={cx(classes.col, classes.collg)}
-            >
+            <ColContainer item container wrap="wrap" $colType="collg">
               <ResultItemTruncatedCell
                 searchResult={searchResult}
                 truncatedCellType="datasetsList"
               />
-            </Grid>
-            <Grid item className={cx(classes.col, classes.collg)}>
+            </ColContainer>
+            <ColContainer item $colType="collg">
               <ResultItemTruncatedCell
                 searchResult={searchResult}
                 truncatedCellType="linkedUrlList"
               />
-            </Grid>
+            </ColContainer>
           </>
         ) : null}
-        <Grid item className={cx(classes.col, classes.colmd)}>
+        <ColContainer item $colType="colmd">
           <Typography
             variant="body1"
             title={searchResult.dataSource.namespace?.name}
@@ -135,8 +187,8 @@ const ResultItem: React.FC<ResultItemProps> = ({
           >
             {searchResult.dataSource.namespace?.name}
           </Typography>
-        </Grid>
-        <Grid item className={cx(classes.col, classes.colmd)}>
+        </ColContainer>
+        <ColContainer item $colType="colmd">
           <Typography
             variant="body1"
             title={searchResult.dataSource?.name}
@@ -144,8 +196,8 @@ const ResultItem: React.FC<ResultItemProps> = ({
           >
             {searchResult.dataSource?.name}
           </Typography>
-        </Grid>
-        <Grid item className={cx(classes.col, classes.colmd)}>
+        </ColContainer>
+        <ColContainer item $colType="colmd">
           <Grid container direction="column" alignItems="flex-start">
             {searchResult.ownership?.map(ownership => (
               <Grid item key={ownership.id}>
@@ -159,8 +211,8 @@ const ResultItem: React.FC<ResultItemProps> = ({
               </Grid>
             ))}
           </Grid>
-        </Grid>
-        <Grid item className={cx(classes.col, classes.colsm)}>
+        </ColContainer>
+        <ColContainer item $colType="colsm">
           <Typography
             variant="body1"
             title={
@@ -174,8 +226,8 @@ const ResultItem: React.FC<ResultItemProps> = ({
               ? format(searchResult.createdAt, 'd MMM yyyy')
               : null}
           </Typography>
-        </Grid>
-        <Grid item className={cx(classes.col, classes.colsm)}>
+        </ColContainer>
+        <ColContainer item $colType="colsm">
           <Typography
             variant="body1"
             title={
@@ -193,10 +245,10 @@ const ResultItem: React.FC<ResultItemProps> = ({
                 })
               : null}
           </Typography>
-        </Grid>
-      </Grid>
-    </Link>
+        </ColContainer>
+      </Container>
+    </ItemLink>
   );
 };
 
-export default withStyles(styles)(ResultItem);
+export default ResultItem;

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemContainer.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemContainer.tsx
@@ -1,0 +1,31 @@
+import { connect } from 'react-redux';
+import { RootState } from 'redux/interfaces';
+import {
+  getDataEntityDetails,
+  getDataEntityDetailsFetching,
+} from 'redux/selectors/dataentity.selectors';
+import { fetchDataEntityDetails } from 'redux/thunks';
+import {
+  getDataEntityCustomMetadataList,
+  getDataEntityPredefinedMetadataList,
+} from 'redux/selectors/metadata.selectors';
+import ResultItem from './ResultItem';
+
+const mapStateToProps = (
+  state: RootState,
+  { dataEntityId }: { dataEntityId: number }
+) => ({
+  dataEntityDetails: getDataEntityDetails(state, dataEntityId),
+  isDataEntityLoading: getDataEntityDetailsFetching(state),
+  predefinedMetadata: getDataEntityPredefinedMetadataList(
+    state,
+    dataEntityId
+  ),
+  customMetadata: getDataEntityCustomMetadataList(state, dataEntityId),
+});
+
+const mapDispatchToProps = {
+  fetchDataEntityDetails,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(ResultItem);

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreview.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreview.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Grid, Typography } from '@mui/material';
+import * as S from 'components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreviewStyles';
+import LabeledInfoItem from 'components/shared/LabeledInfoItem/LabeledInfoItem';
+import NumberFormatted from 'components/shared/NumberFormatted/NumberFormatted';
+import {
+  DataEntityDetails,
+  MetadataFieldType,
+  MetadataFieldValue,
+} from 'generated-sources';
+import BooleanFormatted from 'components/shared/BooleanFormatted/BooleanFormatted';
+import { format } from 'date-fns';
+import AppCircularProgress from 'components/shared/AppCircularProgress/AppCircularProgress';
+
+interface ResultItemPreviewProps {
+  dataEntityDetails: DataEntityDetails;
+  isDataEntityLoading: boolean;
+  predefinedMetadata: MetadataFieldValue[];
+  customMetadata: MetadataFieldValue[];
+}
+
+const ResultItemPreview: React.FC<ResultItemPreviewProps> = ({
+  dataEntityDetails,
+  isDataEntityLoading,
+  predefinedMetadata,
+  customMetadata,
+}) => {
+  const metadataNum = 5;
+
+  const getMetadataValue = (metadataItem: MetadataFieldValue) => {
+    let metadataVal;
+    try {
+      switch (metadataItem.field.type) {
+        case MetadataFieldType.BOOLEAN:
+          metadataVal = <BooleanFormatted value={metadataItem.value} />;
+          break;
+        case MetadataFieldType.DATETIME:
+          metadataVal = format(new Date(metadataItem.value), 'd MMM yyyy');
+          break;
+        case MetadataFieldType.ARRAY:
+          metadataVal = JSON.parse(metadataItem.value).join(', ');
+          break;
+        default:
+          metadataVal = metadataItem.value;
+      }
+    } catch {
+      metadataVal = metadataItem.value;
+    }
+    return metadataVal;
+  };
+
+  return (
+    <S.Container container>
+      {!isDataEntityLoading ? (
+        <>
+          <Grid container>
+            <Grid container justifyContent="space-between" sx={{ mb: 1 }}>
+              <Typography variant="h4" color="text.primary">
+                Custom metadata
+              </Typography>
+              <Typography variant="subtitle1" color="texts.info">
+                <NumberFormatted value={customMetadata.length} /> fields
+              </Typography>
+            </Grid>
+            {customMetadata.length ? (
+              customMetadata.slice(0, metadataNum).map(metadata => (
+                <LabeledInfoItem
+                  key={metadata.field.id}
+                  inline
+                  label={metadata.field.name}
+                  labelWidth={4}
+                >
+                  {getMetadataValue(metadata)}
+                </LabeledInfoItem>
+              ))
+            ) : (
+              <Typography variant="body1" color="texts.secondary">
+                No custom metadata
+              </Typography>
+            )}
+          </Grid>
+          <Grid container sx={{ mt: 2 }}>
+            <Grid container justifyContent="space-between" sx={{ mb: 1 }}>
+              <Typography variant="h4" color="text.primary">
+                Predefined metadata
+              </Typography>
+              <Typography variant="subtitle1" color="texts.info">
+                <NumberFormatted value={predefinedMetadata.length} />{' '}
+                fields
+              </Typography>
+            </Grid>
+            {predefinedMetadata.length ? (
+              predefinedMetadata.slice(0, metadataNum).map(metadata => (
+                <LabeledInfoItem
+                  key={metadata.field.id}
+                  inline
+                  label={metadata.field.name}
+                  labelWidth={4}
+                >
+                  {getMetadataValue(metadata)}
+                </LabeledInfoItem>
+              ))
+            ) : (
+              <Typography variant="body1" color="texts.secondary">
+                No predefined metadata
+              </Typography>
+            )}
+          </Grid>
+          <S.AboutContainer container sx={{ mt: 2 }}>
+            <Grid container justifyContent="space-between" sx={{ mb: 1 }}>
+              <Typography variant="h4" color="text.primary">
+                About
+              </Typography>
+            </Grid>
+            <S.AboutText variant="body1" color="texts.secondary">
+              {dataEntityDetails?.internalDescription || 'Not created'}
+            </S.AboutText>
+          </S.AboutContainer>
+        </>
+      ) : (
+        <Grid container justifyContent="center">
+          <AppCircularProgress
+            background="transparent"
+            progressBackground="dark"
+            size={50}
+          />
+        </Grid>
+      )}
+    </S.Container>
+  );
+};
+export default ResultItemPreview;

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreview.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreview.tsx
@@ -4,6 +4,7 @@ import * as S from 'components/Search/Results/ResultItem/ResultItemPreview/Resul
 import LabeledInfoItem from 'components/shared/LabeledInfoItem/LabeledInfoItem';
 import NumberFormatted from 'components/shared/NumberFormatted/NumberFormatted';
 import {
+  DataEntityApiGetDataEntityDetailsRequest,
   DataEntityDetails,
   MetadataFieldType,
   MetadataFieldValue,
@@ -13,19 +14,32 @@ import { format } from 'date-fns';
 import AppCircularProgress from 'components/shared/AppCircularProgress/AppCircularProgress';
 
 interface ResultItemPreviewProps {
+  dataEntityId: number;
   dataEntityDetails: DataEntityDetails;
   isDataEntityLoading: boolean;
   predefinedMetadata: MetadataFieldValue[];
   customMetadata: MetadataFieldValue[];
+  fetchDataEntityDetails: (
+    params: DataEntityApiGetDataEntityDetailsRequest
+  ) => void;
+  fetchData?: boolean;
 }
 
 const ResultItemPreview: React.FC<ResultItemPreviewProps> = ({
+  dataEntityId,
   dataEntityDetails,
   isDataEntityLoading,
   predefinedMetadata,
   customMetadata,
+  fetchDataEntityDetails,
+  fetchData,
 }) => {
   const metadataNum = 5;
+
+  React.useEffect(() => {
+    if (fetchData && !dataEntityDetails)
+      fetchDataEntityDetails({ dataEntityId });
+  }, [fetchData, dataEntityDetails, dataEntityId, fetchDataEntityDetails]);
 
   const getMetadataValue = (metadataItem: MetadataFieldValue) => {
     let metadataVal;

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreviewContainer.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreviewContainer.tsx
@@ -9,7 +9,7 @@ import {
   getDataEntityCustomMetadataList,
   getDataEntityPredefinedMetadataList,
 } from 'redux/selectors/metadata.selectors';
-import ResultItem from './ResultItem';
+import ResultItemPreview from './ResultItemPreview';
 
 const mapStateToProps = (
   state: RootState,
@@ -28,4 +28,7 @@ const mapDispatchToProps = {
   fetchDataEntityDetails,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(ResultItem);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ResultItemPreview);

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreviewStyles.ts
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreviewStyles.ts
@@ -1,0 +1,21 @@
+import { Grid, Typography } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+export const Container = styled(Grid)(({ theme }) => ({
+  padding: theme.spacing(1),
+  width: '269px',
+  minHeight: '255px',
+}));
+
+export const AboutContainer = styled(Grid)(({ theme }) => ({
+  borderTop: '1px solid',
+  borderTopColor: theme.palette.divider,
+  paddingTop: theme.spacing(2),
+}));
+
+export const AboutText = styled(Typography)(({ theme }) => ({
+  display: '-webkit-box',
+  overflow: 'hidden',
+  '-webkit-line-clamp': '4',
+  '-webkit-box-orient': 'vertical',
+}));

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemStyles.ts
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItemStyles.ts
@@ -1,28 +1,22 @@
-import { Theme } from '@mui/material';
-import { WithStyles } from '@mui/styles';
-import createStyles from '@mui/styles/createStyles';
-import { colWidthStyles } from 'components/Search/Results/ResultsStyles';
+import { Grid } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { Link } from 'react-router-dom';
 
-export const styles = (theme: Theme) =>
-  createStyles({
-    container: {
-      borderBottom: '1px solid',
-      borderBottomColor: theme.palette.divider,
-      padding: theme.spacing(1.25, 0),
-      textDecoration: 'none',
-      cursor: 'pointer',
-      alignItems: 'center',
-      '&:hover': {
-        backgroundColor: theme.palette.backgrounds.primary,
-      },
-    },
-    itemLink: {
-      color: 'initial',
-      textDecoration: 'none',
-      flexGrow: 1,
-      overflow: 'hidden',
-    },
-    ...colWidthStyles,
-  });
+export const Container = styled(Grid)(({ theme }) => ({
+  borderBottom: '1px solid',
+  borderBottomColor: theme.palette.divider,
+  padding: theme.spacing(1.25, 0),
+  textDecoration: 'none',
+  cursor: 'pointer',
+  alignItems: 'center',
+  '&:hover': {
+    backgroundColor: theme.palette.backgrounds.primary,
+  },
+}));
 
-export type StylesType = WithStyles<typeof styles>;
+export const ItemLink = styled(Link)(({ theme }) => ({
+  color: 'initial',
+  textDecoration: 'none',
+  flexGrow: 1,
+  overflow: 'hidden',
+}));

--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import { Grid, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import { useDispatch } from 'react-redux';
 import InfiniteScroll from 'react-infinite-scroll-component';
-import cx from 'classnames';
 import get from 'lodash/get';
 import { Dictionary } from 'lodash/index';
 import {
-  DataEntityTypeNameEnum,
   DataEntity,
-  SearchApiGetSearchResultsRequest,
   DataEntityType,
+  DataEntityTypeNameEnum,
+  SearchApiGetSearchResultsRequest,
 } from 'generated-sources';
 import {
   CurrentPageInfo,
@@ -22,10 +21,10 @@ import EmptyContentPlaceholder from 'components/shared/EmptyContentPlaceholder/E
 import SearchResultsSkeletonItem from 'components/Search/Results/SearchResultsSkeletonItem/SearchResultsSkeletonItem';
 import SearchTabsSkeleton from 'components/Search/Results/SearchTabsSkeleton/SearchTabsSkeleton';
 import SkeletonWrapper from 'components/shared/SkeletonWrapper/SkeletonWrapper';
-import ResultItem from './ResultItem/ResultItem';
-import { StylesType } from './ResultsStyles';
+import ResultItemContainer from 'components/Search/Results/ResultItem/ResultItemContainer';
+import * as S from './ResultsStyles';
 
-interface ResultsProps extends StylesType {
+interface ResultsProps {
   dataEntityTypesByName: Dictionary<DataEntityType>;
   searchId: string;
   searchType?: SearchType;
@@ -43,7 +42,6 @@ interface ResultsProps extends StylesType {
 }
 
 const Results: React.FC<ResultsProps> = ({
-  classes,
   dataEntityTypesByName,
   searchId,
   searchType,
@@ -133,7 +131,7 @@ const Results: React.FC<ResultsProps> = ({
   }, [searchFiltersSynced, searchId, isSearchCreating]);
 
   return (
-    <div className={classes.container}>
+    <S.Container sx={{ mt: 2 }}>
       {isSearchCreatingAndFetching ? (
         <SearchTabsSkeleton length={tabs.length} />
       ) : (
@@ -145,68 +143,68 @@ const Results: React.FC<ResultsProps> = ({
           isHintUpdated={isSearchUpdated}
         />
       )}
-      <Grid container className={classes.resultsTableHeader} wrap="nowrap">
-        <Grid item className={cx(classes.col, classes.collg)}>
+      <S.ResultsTableHeader container sx={{ mt: 2 }} wrap="nowrap">
+        <S.ColContainer item $colType="collg">
           <Typography variant="caption">Name</Typography>
-        </Grid>
+        </S.ColContainer>
         {searchType &&
         searchType === totals[DataEntityTypeNameEnum.SET]?.id ? (
           <>
-            <Grid item className={cx(classes.col, classes.colxs)}>
+            <S.ColContainer item $colType="colxs">
               <Typography variant="caption">Use</Typography>
-            </Grid>
-            <Grid item className={cx(classes.col, classes.colxs)}>
+            </S.ColContainer>
+            <S.ColContainer item $colType="colxs">
               <Typography variant="caption">Rows</Typography>
-            </Grid>
-            <Grid item className={cx(classes.col, classes.colxs)}>
+            </S.ColContainer>
+            <S.ColContainer item $colType="colxs">
               <Typography variant="caption">Columns</Typography>
-            </Grid>
+            </S.ColContainer>
           </>
         ) : null}
         {searchType &&
         searchType === totals[DataEntityTypeNameEnum.TRANSFORMER]?.id ? (
           <>
-            <Grid item className={cx(classes.col, classes.collg)}>
+            <S.ColContainer item $colType="collg">
               <Typography variant="caption">Sources</Typography>
-            </Grid>
-            <Grid item className={cx(classes.col, classes.collg)}>
+            </S.ColContainer>
+            <S.ColContainer item $colType="collg">
               <Typography variant="caption">Targets</Typography>
-            </Grid>
+            </S.ColContainer>
           </>
         ) : null}
         {searchType &&
         searchType === totals[DataEntityTypeNameEnum.QUALITY_TEST]?.id ? (
           <>
-            <Grid item className={cx(classes.col, classes.collg)}>
+            <S.ColContainer item $colType="collg">
               <Typography variant="caption">Entities</Typography>
-            </Grid>
-            <Grid item className={cx(classes.col, classes.collg)}>
+            </S.ColContainer>
+            <S.ColContainer item $colType="collg">
               <Typography variant="caption">Suite URL</Typography>
-            </Grid>
+            </S.ColContainer>
           </>
         ) : null}
         {searchType &&
         searchType === totals[DataEntityTypeNameEnum.CONSUMER]?.id ? (
-          <Grid item className={cx(classes.col, classes.collg)}>
+          <S.ColContainer item $colType="collg">
             <Typography variant="caption">Source</Typography>
-          </Grid>
+          </S.ColContainer>
         ) : null}
-        <Grid item className={cx(classes.col, classes.colmd)}>
+        <S.ColContainer item $colType="colmd">
           <Typography variant="caption">Namespace</Typography>
-        </Grid>
-        <Grid item className={cx(classes.col, classes.colmd)}>
+        </S.ColContainer>
+        <S.ColContainer item $colType="colmd">
           <Typography variant="caption">Datasource</Typography>
-        </Grid>
-        <Grid item className={cx(classes.col, classes.colmd)}>
+        </S.ColContainer>
+        <S.ColContainer item $colType="colmd">
           <Typography variant="caption">Owners</Typography>
-        </Grid>
-        <Grid item className={cx(classes.col, classes.colsm)}>
+        </S.ColContainer>
+        <S.ColContainer item $colType="colsm">
           <Typography variant="caption">Created</Typography>
-        </Grid>
-        <Grid item className={cx(classes.col, classes.colsm)}>
+        </S.ColContainer>
+        <S.ColContainer item $colType="colsm">
           <Typography variant="caption">Last Update</Typography>
-        </Grid>
-      </Grid>
+        </S.ColContainer>
+      </S.ResultsTableHeader>
       {isSearchCreating ? (
         <SkeletonWrapper
           length={10}
@@ -218,7 +216,7 @@ const Results: React.FC<ResultsProps> = ({
           )}
         />
       ) : (
-        <div id="results-list" className={classes.listContainer}>
+        <S.ListContainer id="results-list">
           <InfiniteScroll
             dataLength={searchResults.length}
             next={fetchNextPage}
@@ -240,10 +238,10 @@ const Results: React.FC<ResultsProps> = ({
             scrollableTarget="results-list"
           >
             {searchResults.map(searchResult => (
-              <ResultItem
+              <ResultItemContainer
+                dataEntityId={searchResult.id}
                 key={searchResult.id}
                 searchType={searchType}
-                classes={{ container: classes.resultItem }}
                 searchResult={searchResult}
                 totals={totals}
               />
@@ -252,9 +250,9 @@ const Results: React.FC<ResultsProps> = ({
           {!isSearchFetching && !pageInfo.total ? (
             <EmptyContentPlaceholder text="No matches found" />
           ) : null}
-        </div>
+        </S.ListContainer>
       )}
-    </div>
+    </S.Container>
   );
 };
 

--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -21,7 +21,7 @@ import EmptyContentPlaceholder from 'components/shared/EmptyContentPlaceholder/E
 import SearchResultsSkeletonItem from 'components/Search/Results/SearchResultsSkeletonItem/SearchResultsSkeletonItem';
 import SearchTabsSkeleton from 'components/Search/Results/SearchTabsSkeleton/SearchTabsSkeleton';
 import SkeletonWrapper from 'components/shared/SkeletonWrapper/SkeletonWrapper';
-import ResultItemContainer from 'components/Search/Results/ResultItem/ResultItemContainer';
+import ResultItem from 'components/Search/Results/ResultItem/ResultItem';
 import * as S from './ResultsStyles';
 
 interface ResultsProps {
@@ -238,7 +238,7 @@ const Results: React.FC<ResultsProps> = ({
             scrollableTarget="results-list"
           >
             {searchResults.map(searchResult => (
-              <ResultItemContainer
+              <ResultItem
                 dataEntityId={searchResult.id}
                 key={searchResult.id}
                 searchType={searchType}

--- a/odd-platform-ui/src/components/Search/Results/ResultsContainer.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultsContainer.tsx
@@ -1,22 +1,20 @@
 import { connect } from 'react-redux';
 import { RootState } from 'redux/interfaces';
-import withStyles from '@mui/styles/withStyles';
 import {
-  getSearchTotals,
-  getSearchResults,
   getSearchEntityType,
-  getSearchId,
-  getSearchResultsPage,
   getSearchFiltersSynced,
+  getSearchId,
+  getSearchIsCreating,
+  getSearchIsCreatingAndFetching,
   getSearchIsFetching,
   getSearchIsUpdated,
-  getSearchIsCreatingAndFetching,
-  getSearchIsCreating,
+  getSearchResults,
+  getSearchResultsPage,
+  getSearchTotals,
 } from 'redux/selectors/dataentitySearch.selectors';
 import { getDataEntityTypesByName } from 'redux/selectors/dataentity.selectors';
 import { getDataEntitiesSearchResults } from 'redux/thunks/dataentitiesSearch.thunks';
 import Results from './Results';
-import { styles } from './ResultsStyles';
 
 const mapStateToProps = (state: RootState) => ({
   searchId: getSearchId(state),
@@ -36,7 +34,4 @@ const mapDispatchToProps = {
   getDataEntitiesSearchResults,
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(withStyles(styles)(Results));
+export default connect(mapStateToProps, mapDispatchToProps)(Results);

--- a/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
+++ b/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
@@ -1,10 +1,14 @@
-import { Theme } from '@mui/material';
-import { WithStyles } from '@mui/styles';
-import createStyles from '@mui/styles/createStyles';
+import { Grid } from '@mui/material';
 import { searchHeight } from 'components/shared/MainSearch/MainSearchStyles';
-import { primaryTabsHeight, toolbarHeight } from 'lib/constants';
+import {
+  primaryTabsHeight,
+  tabsContainerMargin,
+  toolbarHeight,
+} from 'lib/constants';
+import { styled } from '@mui/material/styles';
+import { propsChecker } from 'lib/helpers';
 
-const tabsContainerMargin = 16;
+export type ColType = 'col' | 'colxs' | 'colsm' | 'colmd' | 'collg';
 export const colWidthStyles = {
   colxs: {
     flex: '2 0 6%',
@@ -29,34 +33,25 @@ export const colWidthStyles = {
     },
   },
 };
-export const styles = (theme: Theme) =>
-  createStyles({
-    container: {
-      marginTop: theme.spacing(2),
-    },
-    tabsContainer: {
-      marginBottom: `${tabsContainerMargin}px`,
-    },
-    resultsTableHeader: {
-      marginTop: theme.spacing(2),
-      '& > *': {
-        borderBottom: '1px solid',
-        borderBottomColor: theme.palette.divider,
-      },
-    },
-    listContainer: {
-      height: `calc(100vh - ${toolbarHeight}px - ${searchHeight}px - ${primaryTabsHeight}px - ${tabsContainerMargin}px - ${theme.spacing(
-        8
-      )})`,
-      overflow: 'auto',
-    },
-    resultItem: {
-      '&:not(:last-of-type)': {
-        borderBottom: '1px solid',
-        borderBottomColor: theme.palette.divider,
-      },
-    },
-    ...colWidthStyles,
-  });
 
-export type StylesType = WithStyles<typeof styles>;
+export const Container = styled(Grid)(({ theme }) => ({}));
+export const ResultsTableHeader = styled(Grid)(({ theme }) => ({
+  borderBottom: '1px solid',
+  borderBottomColor: theme.palette.divider,
+}));
+
+export const ColContainer = styled(Grid, {
+  shouldForwardProp: propsChecker,
+})<{
+  $colType: ColType;
+}>(({ theme, $colType }) => ({
+  ...colWidthStyles.col,
+  ...colWidthStyles[$colType],
+}));
+
+export const ListContainer = styled(Grid)(({ theme }) => ({
+  height: `calc(100vh - ${toolbarHeight}px - ${searchHeight}px - ${primaryTabsHeight}px - ${tabsContainerMargin}px - ${theme.spacing(
+    8
+  )})`,
+  overflow: 'auto',
+}));

--- a/odd-platform-ui/src/components/shared/AppTooltip/AppTooltip.tsx
+++ b/odd-platform-ui/src/components/shared/AppTooltip/AppTooltip.tsx
@@ -13,6 +13,7 @@ interface AppTooltipProps extends Pick<TooltipProps, 'place' | 'offset'> {
   place?: TooltipProps['place'];
   maxWidth?: number;
   sx?: SxProps<Theme>;
+  onMouseEnterCallback?: () => void;
 }
 
 const AppTooltip: React.FC<AppTooltipProps> = ({
@@ -25,6 +26,7 @@ const AppTooltip: React.FC<AppTooltipProps> = ({
   offset,
   maxWidth,
   sx,
+  onMouseEnterCallback,
 }) => {
   const tagList = ['svg'];
 
@@ -53,7 +55,11 @@ const AppTooltip: React.FC<AppTooltipProps> = ({
   );
 
   return (
-    <S.Container $maxWidth={maxWidth} sx={sx}>
+    <S.Container
+      $maxWidth={maxWidth}
+      sx={sx}
+      onMouseEnter={onMouseEnterCallback}
+    >
       {hasOverflow || controlChecker || !overflowCheck ? (
         <ReactTooltip
           id={id}

--- a/odd-platform-ui/src/components/shared/AppTooltip/AppTooltip.tsx
+++ b/odd-platform-ui/src/components/shared/AppTooltip/AppTooltip.tsx
@@ -6,7 +6,7 @@ import { Theme } from '@mui/material';
 import * as S from './AppTooltipStyles';
 
 interface AppTooltipProps extends Pick<TooltipProps, 'place' | 'offset'> {
-  renderTitle: (props: {
+  renderContent: (props: {
     isTooltipShown?: boolean;
   }) => React.ReactElement | string | undefined;
   type?: 'light' | 'dark';
@@ -18,7 +18,7 @@ interface AppTooltipProps extends Pick<TooltipProps, 'place' | 'offset'> {
 }
 
 const AppTooltip: React.FC<AppTooltipProps> = ({
-  renderTitle,
+  renderContent,
   children,
   type = 'light',
   control = 'byHover',
@@ -80,7 +80,7 @@ const AppTooltip: React.FC<AppTooltipProps> = ({
               : { right: 60 })
           }
         >
-          {renderTitle({ isTooltipShown })}
+          {renderContent({ isTooltipShown })}
         </ReactTooltip>
       ) : null}
       <S.ChildrenContainer
@@ -90,6 +90,7 @@ const AppTooltip: React.FC<AppTooltipProps> = ({
         data-event={controlChecker ? 'click' : null}
         ref={childrenRef}
       >
+        {/* Tooltip call element (by click or hover) */}
         {children}
       </S.ChildrenContainer>
     </S.Container>

--- a/odd-platform-ui/src/components/shared/AppTooltip/AppTooltip.tsx
+++ b/odd-platform-ui/src/components/shared/AppTooltip/AppTooltip.tsx
@@ -6,18 +6,19 @@ import { Theme } from '@mui/material';
 import * as S from './AppTooltipStyles';
 
 interface AppTooltipProps extends Pick<TooltipProps, 'place' | 'offset'> {
-  title: string | JSX.Element | undefined;
+  renderTitle: (props: {
+    isTooltipShown?: boolean;
+  }) => React.ReactElement | string | undefined;
   type?: 'light' | 'dark';
   control?: 'byClick' | 'byHover';
   overflowCheck?: boolean;
   place?: TooltipProps['place'];
   maxWidth?: number;
   sx?: SxProps<Theme>;
-  onMouseEnterCallback?: () => void;
 }
 
 const AppTooltip: React.FC<AppTooltipProps> = ({
-  title,
+  renderTitle,
   children,
   type = 'light',
   control = 'byHover',
@@ -26,9 +27,12 @@ const AppTooltip: React.FC<AppTooltipProps> = ({
   offset,
   maxWidth,
   sx,
-  onMouseEnterCallback,
 }) => {
   const tagList = ['svg'];
+
+  const [isTooltipShown, setIsTooltipShown] = React.useState<boolean>(
+    false
+  );
 
   const childrenRef = React.useRef<HTMLDivElement>(null);
   const [hasOverflow, setOverflow] = React.useState<boolean>(false);
@@ -58,7 +62,8 @@ const AppTooltip: React.FC<AppTooltipProps> = ({
     <S.Container
       $maxWidth={maxWidth}
       sx={sx}
-      onMouseEnter={onMouseEnterCallback}
+      onMouseEnter={() => setIsTooltipShown(true)}
+      onMouseLeave={() => setIsTooltipShown(false)}
     >
       {hasOverflow || controlChecker || !overflowCheck ? (
         <ReactTooltip
@@ -75,7 +80,7 @@ const AppTooltip: React.FC<AppTooltipProps> = ({
               : { right: 60 })
           }
         >
-          {title}
+          {renderTitle({ isTooltipShown })}
         </ReactTooltip>
       ) : null}
       <S.ChildrenContainer

--- a/odd-platform-ui/src/components/shared/AppTooltip/AppTooltipStyles.ts
+++ b/odd-platform-ui/src/components/shared/AppTooltip/AppTooltipStyles.ts
@@ -13,7 +13,6 @@ export const Container = styled('div', {
   shouldForwardProp: propsChecker,
 })<ContainerProps>(({ theme, $maxWidth }) => ({
   margin: 'auto 0',
-  overflow: 'auto',
   '& .__react_component_tooltip:after, .__react_component_tooltip:before': {
     content: 'none',
   },

--- a/odd-platform-ui/src/components/shared/LabeledInfoItem/LabeledInfoItem.tsx
+++ b/odd-platform-ui/src/components/shared/LabeledInfoItem/LabeledInfoItem.tsx
@@ -29,7 +29,7 @@ const LabeledInfoItem: React.FC<LabeledInfoItemProps> = ({
     className={cx(classes.container, { [classes.inline]: inline })}
   >
     <Grid item xs={labelWidth || 'auto'}>
-      <Typography variant={variant} className={classes.label}>
+      <Typography variant={variant} className={classes.label} noWrap>
         {label}
       </Typography>
     </Grid>
@@ -41,7 +41,7 @@ const LabeledInfoItem: React.FC<LabeledInfoItemProps> = ({
           : 'auto'
       }
     >
-      <Typography variant={variant} className={classes.value}>
+      <Typography variant={variant} className={classes.value} noWrap>
         {children}
       </Typography>
     </Grid>

--- a/odd-platform-ui/src/components/shared/LabeledInfoItem/LabeledInfoItemStyles.ts
+++ b/odd-platform-ui/src/components/shared/LabeledInfoItem/LabeledInfoItemStyles.ts
@@ -21,9 +21,11 @@ export const styles = (theme: Theme) =>
     label: {
       color: theme.palette.texts.secondary,
       lineHeight: theme.typography.h3.lineHeight,
+      overflow: 'hidden',
     },
     value: {
       wordBreak: 'break-all',
+      overflow: 'hidden',
     },
   });
 

--- a/odd-platform-ui/src/lib/constants.ts
+++ b/odd-platform-ui/src/lib/constants.ts
@@ -15,5 +15,6 @@ export const maxContentWidthWithoutSidebar = 1440;
 // main skeleton height constant
 export const mainSkeletonHeight = '100%';
 
-// tabs height
+// tabs constants
 export const primaryTabsHeight = 32;
+export const tabsContainerMargin = 16;

--- a/odd-platform-ui/src/redux/interfaces/datasetStructure.ts
+++ b/odd-platform-ui/src/redux/interfaces/datasetStructure.ts
@@ -30,9 +30,20 @@ export const DatasetTypeLabelMap: Map<
   [DataSetFieldTypeTypeEnum.DATETIME, { short: 'Date', plural: 'dates' }],
   [DataSetFieldTypeTypeEnum.BINARY, { short: 'Bin', plural: 'binaries' }],
   [DataSetFieldTypeTypeEnum.NUMBER, { short: 'Dec', plural: 'decimals' }],
-  [DataSetFieldTypeTypeEnum.STRUCT, { short: 'Struct', plural: '' }],
-  [DataSetFieldTypeTypeEnum.LIST, { short: 'List', plural: '' }],
-  [DataSetFieldTypeTypeEnum.MAP, { short: 'Map', plural: '' }],
+  [
+    DataSetFieldTypeTypeEnum.STRUCT,
+    { short: 'Struct', plural: 'structures' },
+  ],
+  [DataSetFieldTypeTypeEnum.LIST, { short: 'List', plural: 'lists' }],
+  [DataSetFieldTypeTypeEnum.MAP, { short: 'Map', plural: 'maps' }],
+  [DataSetFieldTypeTypeEnum.CHAR, { short: 'Char', plural: 'chars' }],
+  [DataSetFieldTypeTypeEnum.TIME, { short: 'Time', plural: 'times' }],
+  [DataSetFieldTypeTypeEnum.UNION, { short: 'Union', plural: 'unions' }],
+  [
+    DataSetFieldTypeTypeEnum.DURATION,
+    { short: 'Dur', plural: 'durations' },
+  ],
+  [DataSetFieldTypeTypeEnum.UNKNOWN, { short: 'Unk', plural: 'unknowns' }],
 ]);
 
 export type DataSetFormattedStatsKeys = keyof Required<DataSetFormattedStats>;

--- a/odd-platform-ui/src/theme/palette.ts
+++ b/odd-platform-ui/src/theme/palette.ts
@@ -210,12 +210,11 @@ export const palette = createPalette({
     TYPE_STRUCT: { border: colors.black20 },
     TYPE_LIST: { border: colors.lightGreen60 },
     TYPE_MAP: { border: colors.turquoise40 },
-    // colors will be updated by design
-    TYPE_CHAR: { border: colors.transparent },
-    TYPE_TIME: { border: colors.transparent },
-    TYPE_UNION: { border: colors.transparent },
-    TYPE_DURATION: { border: colors.transparent },
-    TYPE_UNKNOWN: { border: colors.transparent },
+    TYPE_CHAR: { border: colors.green40 },
+    TYPE_TIME: { border: colors.purple5 },
+    TYPE_UNION: { border: colors.blue65 },
+    TYPE_DURATION: { border: colors.blue40 },
+    TYPE_UNKNOWN: { border: colors.black10 },
   },
   alert: {
     OPEN: {


### PR DESCRIPTION
- Implemented data entity preview on search page.
- Refactored ResultsList and ResultItem components to styled.

<img width="1789" alt="Screenshot 2021-11-03 at 15 00 12" src="https://user-images.githubusercontent.com/59020701/140056447-3b840773-d5ef-4927-9167-e9211457c543.png">

<img width="1791" alt="Screenshot 2021-11-03 at 15 01 43" src="https://user-images.githubusercontent.com/59020701/140056436-c569fe3f-1e06-45f7-9e96-39b15492f570.png">

