### PR TITLE
CI env updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,6 @@ jobs:
             ${{ runner.os }}-node-
       - name: Build with Gradle
         env:
-          NODE_ENV: production
           GENERATE_SOURCEMAP: false
           CI: false
           JAVA_OPTS: "-Xms2048m -Xmx2048m"

--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -29,7 +29,6 @@ jobs:
           distribution: 'temurin'
       - name: Run codestyle check
         env:
-          NODE_ENV: production
           GENERATE_SOURCEMAP: false
           CI: false
           JAVA_OPTS: "-Xms512m -Xmx512m"

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -56,7 +56,6 @@ jobs:
           distribution: 'temurin'
       - name: Build with Gradle
         env:
-          NODE_ENV: production
           GENERATE_SOURCEMAP: false
           CI: false
           JAVA_OPTS: "-Xms2048m -Xmx2048m"


### PR DESCRIPTION
Remove NODE_ENV environment variable from CI processes, because development dependencies are not being installed during build part of CI process.

