### PR TITLE
Bugfix/fixing validate dom nesting

### DIFF
--- a/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureTable/DatasetStructureList/DatasetStructureItem/DatasetFieldInfoEditForm/DatasetFieldInfoEditForm.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureTable/DatasetStructureList/DatasetStructureItem/DatasetFieldInfoEditForm/DatasetFieldInfoEditForm.tsx
@@ -94,7 +94,11 @@ const DatasetFieldInfoEditForm: React.FC<DataSetFieldInfoEditFormProps> = ({
     );
   };
 
-  const formTitle = <Typography variant="h4">Edit information</Typography>;
+  const formTitle = (
+    <Typography variant="h4" component="span">
+      Edit information
+    </Typography>
+  );
 
   const formContent = () => (
     <form

--- a/odd-platform-ui/src/components/DataEntityDetails/InternalNameFormDialog/InternalNameFormDialog.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/InternalNameFormDialog/InternalNameFormDialog.tsx
@@ -71,7 +71,7 @@ const InternalNameFormDialog: React.FC<InternalNameFormDialogProps> = ({
   };
 
   const formTitle = (
-    <Typography variant="h4">
+    <Typography variant="h4" component="span">
       {dataEntityInternalName ? 'Edit ' : 'Add '}
       business name
     </Typography>

--- a/odd-platform-ui/src/components/DataEntityDetails/Metadata/MetadataCreateForm/MetadataCreateForm.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Metadata/MetadataCreateForm/MetadataCreateForm.tsx
@@ -84,7 +84,9 @@ const MetadataCreateForm: React.FC<MetadataCreateFormProps> = ({
   };
 
   const formTitle = (
-    <Typography variant="h4">Add Custom Metadata</Typography>
+    <Typography variant="h4" component="span">
+      Add Custom Metadata
+    </Typography>
   );
 
   const formContent = () => (

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewGeneral/OverviewGeneralStyles.ts
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewGeneral/OverviewGeneralStyles.ts
@@ -1,6 +1,7 @@
 import { styled } from '@mui/material/styles';
 
-export const OddrnValue = styled('div')(({ theme }) => ({
+export const OddrnValue = styled('span')(({ theme }) => ({
+  display: 'block',
   width: '100%',
   whiteSpace: 'normal',
   borderRadius: '4px',

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewTags/TagsEditForm/TagsEditForm.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewTags/TagsEditForm/TagsEditForm.tsx
@@ -181,7 +181,11 @@ const TagsEditForm: React.FC<TagsEditProps> = ({
     remove(index);
   };
 
-  const formTitle = <Typography variant="h4">Edit Tags</Typography>;
+  const formTitle = (
+    <Typography variant="h4" component="span">
+      Edit Tags
+    </Typography>
+  );
 
   const formContent = () => (
     <>

--- a/odd-platform-ui/src/components/DataEntityDetails/Ownership/OwnershipForm.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Ownership/OwnershipForm.tsx
@@ -252,7 +252,7 @@ const OwnershipForm: React.FC<OwnershipFormProps> = ({
   };
 
   const formTitle = (
-    <Typography variant="h4">
+    <Typography variant="h4" component="span">
       {dataEntityOwnership ? 'Edit' : 'Add'} owner
     </Typography>
   );

--- a/odd-platform-ui/src/components/Management/DataSourcesList/DataSourceForm/DataSourceForm.tsx
+++ b/odd-platform-ui/src/components/Management/DataSourcesList/DataSourceForm/DataSourceForm.tsx
@@ -178,7 +178,7 @@ const DataSourceForm: React.FC<DataSourceFormDialogProps> = ({
   };
 
   const formTitle = (
-    <Typography variant="h4">
+    <Typography variant="h4" component="span">
       {dataSource ? 'Edit ' : 'Add '}
       Datasource
     </Typography>

--- a/odd-platform-ui/src/components/Management/LabelsList/LabelCreateForm/LabelCreateForm.tsx
+++ b/odd-platform-ui/src/components/Management/LabelsList/LabelCreateForm/LabelCreateForm.tsx
@@ -80,7 +80,11 @@ const LabelCreateForm: React.FC<LabelCreateFormProps> = ({
     if (!fields.length) handleAppend();
   };
 
-  const formTitle = <Typography variant="h4">Create Label</Typography>;
+  const formTitle = (
+    <Typography variant="h4" component="span">
+      Create Label
+    </Typography>
+  );
 
   const formContent = () => (
     <>

--- a/odd-platform-ui/src/components/Management/LabelsList/LabelEditForm/LabelEditForm.tsx
+++ b/odd-platform-ui/src/components/Management/LabelsList/LabelEditForm/LabelEditForm.tsx
@@ -65,7 +65,11 @@ const LabelEditForm: React.FC<LabelEditFormProps> = ({
     );
   };
 
-  const formTitle = <Typography variant="h4">Edit Label</Typography>;
+  const formTitle = (
+    <Typography variant="h4" component="span">
+      Edit Label
+    </Typography>
+  );
 
   const formContent = () => (
     <form id="label-edit-form" onSubmit={handleSubmit(handleUpdate)}>

--- a/odd-platform-ui/src/components/Management/NamespaceList/NamespaceForm/NamespaceForm.tsx
+++ b/odd-platform-ui/src/components/Management/NamespaceList/NamespaceForm/NamespaceForm.tsx
@@ -78,7 +78,7 @@ const NamespaceForm: React.FC<NamespaceFormProps> = ({
   };
 
   const formTitle = (
-    <Typography variant="h4">
+    <Typography variant="h4" component="span">
       {namespace ? 'Edit' : 'Add'} Namespace
     </Typography>
   );

--- a/odd-platform-ui/src/components/Management/OwnersList/OwnerForm/OwnerForm.tsx
+++ b/odd-platform-ui/src/components/Management/OwnersList/OwnerForm/OwnerForm.tsx
@@ -75,7 +75,9 @@ const OwnerForm: React.FC<OwnerFormProps> = ({
   };
 
   const formTitle = (
-    <Typography variant="h4">{owner ? 'Edit' : 'Add'} Owner</Typography>
+    <Typography variant="h4" component="span">
+      {owner ? 'Edit' : 'Add'} Owner
+    </Typography>
   );
 
   const formContent = () => (

--- a/odd-platform-ui/src/components/Management/TagsList/TagCreateForm/TagCreateForm.tsx
+++ b/odd-platform-ui/src/components/Management/TagsList/TagCreateForm/TagCreateForm.tsx
@@ -82,7 +82,11 @@ const TagCreateForm: React.FC<TagCreateFormProps> = ({
     if (!fields.length) handleAppend();
   };
 
-  const formTitle = <Typography variant="h4">Create Tag</Typography>;
+  const formTitle = (
+    <Typography variant="h4" component="span">
+      Create Tag
+    </Typography>
+  );
 
   const formContent = () => (
     <>

--- a/odd-platform-ui/src/components/Management/TagsList/TagEditForm/TagEditForm.tsx
+++ b/odd-platform-ui/src/components/Management/TagsList/TagEditForm/TagEditForm.tsx
@@ -61,7 +61,11 @@ const TagEditForm: React.FC<TagEditFormProps> = ({
     );
   };
 
-  const formTitle = <Typography variant="h4">Edit Tag</Typography>;
+  const formTitle = (
+    <Typography variant="h4" component="span">
+      Edit Tag
+    </Typography>
+  );
 
   const formContent = () => (
     <form id="tag-edit-form" onSubmit={handleSubmit(handleUpdate)}>

--- a/odd-platform-ui/src/components/shared/AppTabs/AppTabLabel/AppTabLabel.tsx
+++ b/odd-platform-ui/src/components/shared/AppTabs/AppTabLabel/AppTabLabel.tsx
@@ -30,11 +30,13 @@ const AppTabLabel: React.FC<AppTabLabelProps> = ({
     );
 
   return (
-    <S.Container variant="body1">
-      {name}
-      {showHint && hint !== undefined
-        ? getLabelContent(isHintUpdated)
-        : null}
+    <S.Container>
+      <Typography variant="body1" component="span">
+        {name}
+        {showHint && hint !== undefined
+          ? getLabelContent(isHintUpdated)
+          : null}
+      </Typography>
     </S.Container>
   );
 };

--- a/odd-platform-ui/src/components/shared/AppTabs/AppTabLabel/AppTabLabel.tsx
+++ b/odd-platform-ui/src/components/shared/AppTabs/AppTabLabel/AppTabLabel.tsx
@@ -30,13 +30,11 @@ const AppTabLabel: React.FC<AppTabLabelProps> = ({
     );
 
   return (
-    <S.Container>
-      <Typography variant="body1" component="span">
-        {name}
-        {showHint && hint !== undefined
-          ? getLabelContent(isHintUpdated)
-          : null}
-      </Typography>
+    <S.Container variant="body1" component="span">
+      {name}
+      {showHint && hint !== undefined
+        ? getLabelContent(isHintUpdated)
+        : null}
     </S.Container>
   );
 };

--- a/odd-platform-ui/src/components/shared/AppTabs/AppTabLabel/AppTabLabelStyles.ts
+++ b/odd-platform-ui/src/components/shared/AppTabs/AppTabLabel/AppTabLabelStyles.ts
@@ -1,10 +1,10 @@
 import { Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-export const Container = styled(Typography)(({ theme }) => ({
+export const Container = styled('span')(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  '& span': {
+  '& span span': {
     backgroundColor: theme.palette.backgrounds.primary,
     borderRadius: '4px',
     lineHeight: '1.1rem',

--- a/odd-platform-ui/src/components/shared/AppTabs/AppTabLabel/AppTabLabelStyles.ts
+++ b/odd-platform-ui/src/components/shared/AppTabs/AppTabLabel/AppTabLabelStyles.ts
@@ -1,10 +1,12 @@
 import { Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-export const Container = styled('span')(({ theme }) => ({
+export const Container = styled(Typography)<{
+  component: React.ElementType;
+}>(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
-  '& span span': {
+  '& span': {
     backgroundColor: theme.palette.backgrounds.primary,
     borderRadius: '4px',
     lineHeight: '1.1rem',

--- a/odd-platform-ui/src/components/shared/AutocompleteSuggestion/AutocompleteSuggestion.tsx
+++ b/odd-platform-ui/src/components/shared/AutocompleteSuggestion/AutocompleteSuggestion.tsx
@@ -14,7 +14,7 @@ const AutocompleteSuggestion: React.FC<AutocompleteSuggestionProps> = ({
   optionName,
   sx,
 }) => (
-  <S.Container sx={sx} variant="body2">
+  <S.Container sx={sx} variant="body2" component="span">
     <S.NoResultText>No result.</S.NoResultText>{' '}
     <S.CreateNewOptionText>
       Create new {optionLabel} &quot;{optionName}&quot;

--- a/odd-platform-ui/src/components/shared/AutocompleteSuggestion/AutocompleteSuggestionStyles.ts
+++ b/odd-platform-ui/src/components/shared/AutocompleteSuggestion/AutocompleteSuggestionStyles.ts
@@ -1,7 +1,10 @@
 import { Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
-export const Container = styled(Typography)(({ theme }) => ({}));
+export const Container = styled(Typography)<{
+  component: React.ElementType;
+}>(({ theme }) => ({}));
+
 export const NoResultText = styled('span')(({ theme }) => ({
   color: theme.palette.texts.secondary,
 }));

--- a/odd-platform-ui/src/components/shared/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/odd-platform-ui/src/components/shared/ConfirmationDialog/ConfirmationDialog.tsx
@@ -32,7 +32,11 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
     }
   };
 
-  const formTitle = <Typography variant="h4">{actionTitle}</Typography>;
+  const formTitle = (
+    <Typography variant="h4" component="span">
+      {actionTitle}
+    </Typography>
+  );
 
   const formContent = () => (
     <Typography variant="subtitle1">{actionText}</Typography>


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?**
<!-- ignore-task-list-end -->
**What changes did you make?**
All modals that uses typography component in DialogTitle now uses span as component i.e. `<Typography variant=<...> component="span">`. On search page now tabs use Typography element with prop component=span.
Reason: DialogTitle uses h2, block elements cannot be children of that tag.
**How Has This Been Tested?**
<!-- ignore-task-list-start -->
- [X] Manually
<!-- ignore-task-list-end -->

**Checklist**
- [X] I have performed a self-review of my own code
Check out [Contributing](https://github.com/opendatadiscovery/odd-platform/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/opendatadiscovery/odd-platform/blob/main/CODE_OF_CONDUCT.md)