### PR TITLE
fixed warning with selectedTab=-1

### DIFF
--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -148,13 +148,16 @@ const Results: React.FC<ResultsProps> = ({
       {isSearchCreatingAndFetching ? (
         <SearchTabsSkeleton length={tabs.length} />
       ) : (
-        <AppTabs
-          type="primary"
-          items={tabs}
-          selectedTab={selectedTab}
-          handleTabChange={onSearchTypeChange}
-          isHintUpdated={isSearchUpdated}
-        />
+        tabs.length &&
+        selectedTab >= 0 && (
+          <AppTabs
+            type="primary"
+            items={tabs}
+            selectedTab={selectedTab}
+            handleTabChange={onSearchTypeChange}
+            isHintUpdated={isSearchUpdated}
+          />
+        )
       )}
       <S.ResultsTableHeader container sx={{ mt: 2 }} wrap="nowrap">
         <S.ColContainer item $colType="collg">


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?**
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
On search page, tabs variable was [] initially and updated using useEffect(), so initially AppTabs component rendered with selectedTab=[].findIndex(...) = -1, and give warning to the console. Fixed issue by rendering AppTabs component conditionally, like it was done in other pages(e.g. Management.tsx).

**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [X] Manually
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [X] I have performed a self-review of my own code

Check out [Contributing](https://github.com/opendatadiscovery/odd-platform/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/opendatadiscovery/odd-platform/blob/main/CODE_OF_CONDUCT.md)