### PR TITLE
Bugfix/tabs prop warning

### DIFF
--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -151,7 +151,7 @@ const Results: React.FC<ResultsProps> = ({
         <AppTabs
           type="primary"
           items={tabs}
-          selectedTab={selectedTab === -1 ? false : selectedTab}
+          selectedTab={selectedTab}
           handleTabChange={onSearchTypeChange}
           isHintUpdated={isSearchUpdated}
         />

--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -148,16 +148,13 @@ const Results: React.FC<ResultsProps> = ({
       {isSearchCreatingAndFetching ? (
         <SearchTabsSkeleton length={tabs.length} />
       ) : (
-        tabs.length &&
-        selectedTab >= 0 && (
-          <AppTabs
-            type="primary"
-            items={tabs}
-            selectedTab={selectedTab}
-            handleTabChange={onSearchTypeChange}
-            isHintUpdated={isSearchUpdated}
-          />
-        )
+        <AppTabs
+          type="primary"
+          items={tabs}
+          selectedTab={selectedTab === -1 ? false : selectedTab}
+          handleTabChange={onSearchTypeChange}
+          isHintUpdated={isSearchUpdated}
+        />
       )}
       <S.ResultsTableHeader container sx={{ mt: 2 }} wrap="nowrap">
         <S.ColContainer item $colType="collg">

--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -148,13 +148,16 @@ const Results: React.FC<ResultsProps> = ({
       {isSearchCreatingAndFetching ? (
         <SearchTabsSkeleton length={tabs.length} />
       ) : (
-        <AppTabs
-          type="primary"
-          items={tabs}
-          selectedTab={selectedTab}
-          handleTabChange={onSearchTypeChange}
-          isHintUpdated={isSearchUpdated}
-        />
+        tabs.length &&
+        selectedTab >= 0 && (
+          <AppTabs
+            type="primary"
+            items={tabs}
+            selectedTab={selectedTab}
+            handleTabChange={onSearchTypeChange}
+            isHintUpdated={isSearchUpdated}
+          />
+        )
       )}
       <S.ResultsTableHeader container sx={{ mt: 2 }} wrap="nowrap">
         <S.ColContainer item $colType="collg">

--- a/odd-platform-ui/src/components/shared/AppTabs/AppTabs.tsx
+++ b/odd-platform-ui/src/components/shared/AppTabs/AppTabs.tsx
@@ -36,7 +36,7 @@ const AppTabs: React.FC<AppTabsProps> = ({
 }) => {
   const [currentTab, setCurrent] = React.useState<
     number | boolean | undefined
-  >(selectedTab);
+  >(selectedTab === -1 ? false : selectedTab);
 
   const handleChange = (event: SyntheticEvent, newTab: number) => {
     setCurrent(newTab);
@@ -44,7 +44,7 @@ const AppTabs: React.FC<AppTabsProps> = ({
   };
 
   React.useEffect(() => {
-    setCurrent(selectedTab);
+    setCurrent(selectedTab === -1 ? false : selectedTab);
   }, [selectedTab]);
 
   return (

--- a/odd-platform-ui/src/components/shared/AppTabs/AppTabs.tsx
+++ b/odd-platform-ui/src/components/shared/AppTabs/AppTabs.tsx
@@ -34,9 +34,10 @@ const AppTabs: React.FC<AppTabsProps> = ({
   isHintUpdated = false,
   sx,
 }) => {
+  const selectedTabState = selectedTab === -1 ? false : selectedTab;
   const [currentTab, setCurrent] = React.useState<
     number | boolean | undefined
-  >(selectedTab === -1 ? false : selectedTab);
+  >(selectedTabState);
 
   const handleChange = (event: SyntheticEvent, newTab: number) => {
     setCurrent(newTab);
@@ -44,7 +45,7 @@ const AppTabs: React.FC<AppTabsProps> = ({
   };
 
   React.useEffect(() => {
-    setCurrent(selectedTab === -1 ? false : selectedTab);
+    setCurrent(selectedTabState);
   }, [selectedTab]);
 
   return (


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing applications:)
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
after tabs.findIndex(...)=-1, there is no tab with that value, so a warning appeared. Fixed by making prop value(selectedTab)=false in that case.
**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "X" next to an item)
<!-- ignore-task-list-start -->
- [X] Manually
<!-- ignore-task-list-end -->

**Checklist** (put an "X" next to an item, otherwise PR will fail)
- [X] I have performed a self-review of my own code

Check out [Contributing](https://github.com/opendatadiscovery/odd-platform/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/opendatadiscovery/odd-platform/blob/main/CODE_OF_CONDUCT.md)