### PR TITLE
fixed search page styles

### DIFF
--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
@@ -7,7 +7,10 @@ import EntityTypeItem from 'components/shared/EntityTypeItem/EntityTypeItem';
 import { dataEntityDetailsPath } from 'lib/paths';
 import TruncatedCell from 'components/shared/TruncatedCell/TruncatedCell';
 import InformationIcon from 'components/shared/Icons/InformationIcon';
-import { ColContainer } from 'components/Search/Results/ResultsStyles';
+import {
+  ColContainer,
+  NameContainer,
+} from 'components/Search/Results/ResultsStyles';
 import ResultItemPreviewContainer from 'components/Search/Results/ResultItem/ResultItemPreview/ResultItemPreviewContainer';
 import AppTooltip from 'components/shared/AppTooltip/AppTooltip';
 import { Container, ItemLink } from './ResultItemStyles';
@@ -35,13 +38,11 @@ const ResultItem: React.FC<ResultItemProps> = ({
           justifyContent="space-between"
           wrap="nowrap"
         >
-          <ColContainer
-            $colType="col"
+          <NameContainer
             container
             item
             justifyContent="flex-start"
             wrap="nowrap"
-            $noPaddings
           >
             <Typography
               variant="body1"
@@ -66,7 +67,7 @@ const ResultItem: React.FC<ResultItemProps> = ({
             >
               <InformationIcon sx={{ display: 'flex' }} />
             </AppTooltip>
-          </ColContainer>
+          </NameContainer>
           <Grid
             container
             item

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
@@ -41,6 +41,7 @@ const ResultItem: React.FC<ResultItemProps> = ({
             item
             justifyContent="flex-start"
             wrap="nowrap"
+            $noPaddings
           >
             <Typography
               variant="body1"

--- a/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
+++ b/odd-platform-ui/src/components/Search/Results/ResultItem/ResultItem.tsx
@@ -38,12 +38,7 @@ const ResultItem: React.FC<ResultItemProps> = ({
           justifyContent="space-between"
           wrap="nowrap"
         >
-          <NameContainer
-            container
-            item
-            justifyContent="flex-start"
-            wrap="nowrap"
-          >
+          <NameContainer container item>
             <Typography
               variant="body1"
               noWrap

--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -104,7 +104,7 @@ const Results: React.FC<ResultsProps> = ({
       },
     ]);
   }, [totals]);
-  const [scrollbarWidth, setScrollbarWidth] = React.useState('0px');
+  const [scrollbarWidth, setScrollbarWidth] = React.useState('15px');
   React.useEffect(() => {
     const newWidth = useScrollBarWidth();
     setScrollbarWidth(newWidth);
@@ -233,9 +233,6 @@ const Results: React.FC<ResultsProps> = ({
         <S.ColContainer item $colType="colsm">
           <Typography variant="caption">Last Update</Typography>
         </S.ColContainer>
-        {/* <S.ColContainer item $noPaddings $colType="col">
-          <S.ScrollbarSizedBox $width={scrollbarWidth} />
-        </S.ColContainer> */}
       </S.ResultsTableHeader>
       {isSearchCreating ? (
         <SkeletonWrapper

--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -104,6 +104,19 @@ const Results: React.FC<ResultsProps> = ({
     ]);
   }, [totals]);
 
+  // Find out dynamically size of scrollbar width of client's browser
+  // For Chrome default is 15px
+  const [scrollbarWidth, setScrollbarWidth] = React.useState('15px');
+  React.useEffect(() => {
+    const scrollDiv = document.createElement('div');
+    scrollDiv.style.overflow = 'scroll';
+    document.body.appendChild(scrollDiv);
+    setScrollbarWidth(
+      `${scrollDiv.offsetWidth - scrollDiv.clientWidth}px`
+    );
+    document.body.removeChild(scrollDiv);
+  }, []);
+
   const [selectedTab, setSelectedTab] = React.useState<number>(-1);
 
   React.useEffect(() => {
@@ -222,6 +235,9 @@ const Results: React.FC<ResultsProps> = ({
         </S.ColContainer>
         <S.ColContainer item $colType="colsm">
           <Typography variant="caption">Last Update</Typography>
+        </S.ColContainer>
+        <S.ColContainer item $noPaddings $colType="col">
+          <S.ScrollbarSizedBox $width={scrollbarWidth} />
         </S.ColContainer>
       </S.ResultsTableHeader>
       {isSearchCreating ? (

--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import get from 'lodash/get';
 import { Dictionary } from 'lodash/index';
+import { useScrollBarWidth } from 'lib/hooks';
 import {
   DataEntity,
   DataEntityType,
@@ -103,18 +104,10 @@ const Results: React.FC<ResultsProps> = ({
       },
     ]);
   }, [totals]);
-
-  // Find out dynamically size of scrollbar width of client's browser
-  // For Chrome default is 15px
-  const [scrollbarWidth, setScrollbarWidth] = React.useState('15px');
+  const [scrollbarWidth, setScrollbarWidth] = React.useState('0px');
   React.useEffect(() => {
-    const scrollDiv = document.createElement('div');
-    scrollDiv.style.overflow = 'scroll';
-    document.body.appendChild(scrollDiv);
-    setScrollbarWidth(
-      `${scrollDiv.offsetWidth - scrollDiv.clientWidth}px`
-    );
-    document.body.removeChild(scrollDiv);
+    const newWidth = useScrollBarWidth();
+    setScrollbarWidth(newWidth);
   }, []);
 
   const [selectedTab, setSelectedTab] = React.useState<number>(-1);
@@ -169,7 +162,11 @@ const Results: React.FC<ResultsProps> = ({
           isHintUpdated={isSearchUpdated}
         />
       )}
-      <S.ResultsTableHeader container sx={{ mt: 2 }} wrap="nowrap">
+      <S.ResultsTableHeader
+        container
+        sx={{ mt: 2, pr: scrollbarWidth }}
+        wrap="nowrap"
+      >
         <S.ColContainer item $colType="collg">
           <Typography variant="caption">Name</Typography>
         </S.ColContainer>
@@ -236,9 +233,9 @@ const Results: React.FC<ResultsProps> = ({
         <S.ColContainer item $colType="colsm">
           <Typography variant="caption">Last Update</Typography>
         </S.ColContainer>
-        <S.ColContainer item $noPaddings $colType="col">
+        {/* <S.ColContainer item $noPaddings $colType="col">
           <S.ScrollbarSizedBox $width={scrollbarWidth} />
-        </S.ColContainer>
+        </S.ColContainer> */}
       </S.ResultsTableHeader>
       {isSearchCreating ? (
         <SkeletonWrapper

--- a/odd-platform-ui/src/components/Search/Results/Results.tsx
+++ b/odd-platform-ui/src/components/Search/Results/Results.tsx
@@ -104,11 +104,7 @@ const Results: React.FC<ResultsProps> = ({
       },
     ]);
   }, [totals]);
-  const [scrollbarWidth, setScrollbarWidth] = React.useState('15px');
-  React.useEffect(() => {
-    const newWidth = useScrollBarWidth();
-    setScrollbarWidth(newWidth);
-  }, []);
+  const scrollbarWidth = useScrollBarWidth();
 
   const [selectedTab, setSelectedTab] = React.useState<number>(-1);
 

--- a/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
+++ b/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
@@ -40,13 +40,6 @@ export const ResultsTableHeader = styled(Grid)(({ theme }) => ({
   borderBottomColor: theme.palette.divider,
 }));
 
-// export const ScrollbarSizedBox = styled('div', {
-//   shouldForwardProp: propsChecker,
-// })<{ $width?: string }>(({ theme, $width }) => ({
-//   width: $width,
-//   height: theme.typography.caption.lineHeight,
-// }));
-
 export const ColContainer = styled(Grid, {
   shouldForwardProp: propsChecker,
 })<{

--- a/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
+++ b/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
@@ -31,6 +31,10 @@ export const colWidthStyles = {
       paddingRight: 0,
     },
   },
+  noPaddings: {
+    paddingLeft: 0,
+    paddingRight: 0,
+  },
 };
 
 const searchHeight = 40;
@@ -40,18 +44,27 @@ export const ResultsTableHeader = styled(Grid)(({ theme }) => ({
   borderBottomColor: theme.palette.divider,
 }));
 
+export const ScrollbarSizedBox = styled('div', {
+  shouldForwardProp: propsChecker,
+})<{ $width?: string }>(({ theme, $width }) => ({
+  width: $width,
+  height: theme.typography.caption.lineHeight,
+}));
+
 export const ColContainer = styled(Grid, {
   shouldForwardProp: propsChecker,
 })<{
   $colType: ColType;
-}>(({ $colType }) => ({
+  $noPaddings?: boolean;
+}>(({ $colType, $noPaddings }) => ({
   ...colWidthStyles.col,
   ...colWidthStyles[$colType],
+  ...($noPaddings && colWidthStyles.noPaddings),
 }));
 
 export const ListContainer = styled(Grid)(({ theme }) => ({
   height: `calc(100vh - ${toolbarHeight}px - ${searchHeight}px - ${primaryTabsHeight}px - ${tabsContainerMargin}px - ${theme.spacing(
     8
   )})`,
-  overflow: 'auto',
+  overflowY: 'scroll',
 }));

--- a/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
+++ b/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
@@ -51,8 +51,9 @@ export const ColContainer = styled(Grid, {
 
 export const NameContainer = styled(Grid)(() => ({
   ...colWidthStyles.col,
-  paddingRight: '0',
-  paddingLeft: '0',
+  padding: 0,
+  justifyContent: 'flex-start',
+  flexWrap: 'nowrap',
 }));
 
 export const ListContainer = styled(Grid)(({ theme }) => ({

--- a/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
+++ b/odd-platform-ui/src/components/Search/Results/ResultsStyles.ts
@@ -31,10 +31,6 @@ export const colWidthStyles = {
       paddingRight: 0,
     },
   },
-  noPaddings: {
-    paddingLeft: 0,
-    paddingRight: 0,
-  },
 };
 
 const searchHeight = 40;
@@ -44,22 +40,26 @@ export const ResultsTableHeader = styled(Grid)(({ theme }) => ({
   borderBottomColor: theme.palette.divider,
 }));
 
-export const ScrollbarSizedBox = styled('div', {
-  shouldForwardProp: propsChecker,
-})<{ $width?: string }>(({ theme, $width }) => ({
-  width: $width,
-  height: theme.typography.caption.lineHeight,
-}));
+// export const ScrollbarSizedBox = styled('div', {
+//   shouldForwardProp: propsChecker,
+// })<{ $width?: string }>(({ theme, $width }) => ({
+//   width: $width,
+//   height: theme.typography.caption.lineHeight,
+// }));
 
 export const ColContainer = styled(Grid, {
   shouldForwardProp: propsChecker,
 })<{
   $colType: ColType;
-  $noPaddings?: boolean;
-}>(({ $colType, $noPaddings }) => ({
+}>(({ $colType }) => ({
   ...colWidthStyles.col,
   ...colWidthStyles[$colType],
-  ...($noPaddings && colWidthStyles.noPaddings),
+}));
+
+export const NameContainer = styled(Grid)(() => ({
+  ...colWidthStyles.col,
+  paddingRight: '0',
+  paddingLeft: '0',
 }));
 
 export const ListContainer = styled(Grid)(({ theme }) => ({

--- a/odd-platform-ui/src/lib/hooks.ts
+++ b/odd-platform-ui/src/lib/hooks.ts
@@ -1,16 +1,25 @@
+import React from 'react';
 /**
  * Find out dynamically size of scrollbar width of client's browser.
  * For Chrome default is 15px
- * @param {number} width - default scrollbar width if hook failed.
- * @returns {string} scrollbar width or default value if calculated value for scrollbar is 0.
+ * @param {number} width in px - default scrollbar width if hook failed.
+ * @returns {string} - scrollbar width in px or default value if calculated value for scrollbar is 0.
  */
-export const useScrollBarWidth = (width = 15) => {
-  const scrollDiv = document.createElement('div');
-  scrollDiv.style.overflow = 'scroll';
-  document.body.appendChild(scrollDiv);
-  const scrollbarWidth = `${
-    scrollDiv.offsetWidth - scrollDiv.clientWidth || width
-  }px`;
-  document.body.removeChild(scrollDiv);
+export const useScrollBarWidth: (width?: number) => string = (
+  width = 15
+) => {
+  const [scrollbarWidth, setScrollbarWidth] = React.useState<string>(
+    `${width}px`
+  );
+  React.useEffect(() => {
+    const scrollDiv = document.createElement('div');
+    scrollDiv.style.overflow = 'scroll';
+    document.body.appendChild(scrollDiv);
+    const calculatedScrollbarWidth = `${
+      scrollDiv.offsetWidth - scrollDiv.clientWidth || width
+    }px`;
+    document.body.removeChild(scrollDiv);
+    setScrollbarWidth(calculatedScrollbarWidth);
+  }, []);
   return scrollbarWidth;
 };

--- a/odd-platform-ui/src/lib/hooks.ts
+++ b/odd-platform-ui/src/lib/hooks.ts
@@ -1,0 +1,16 @@
+/**
+ * Find out dynamically size of scrollbar width of client's browser.
+ * For Chrome default is 15px
+ * @param {number} width - default scrollbar width if hook failed.
+ * @returns {string} scrollbar width or default value if calculated value for scrollbar is 0.
+ */
+export const useScrollBarWidth = (width = 15) => {
+  const scrollDiv = document.createElement('div');
+  scrollDiv.style.overflow = 'scroll';
+  document.body.appendChild(scrollDiv);
+  const scrollbarWidth = `${
+    scrollDiv.offsetWidth - scrollDiv.clientWidth || width
+  }px`;
+  document.body.removeChild(scrollDiv);
+  return scrollbarWidth;
+};


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?**
<!-- ignore-task-list-end -->
**What changes did you make?**
Deleted paddings for an inner container that displays the name(paddings appear twice because the outer container has them too). Added empty container with scrollbar width to the header of the table on the search page.
![Screenshot of styles](https://user-images.githubusercontent.com/62697480/152208309-f50ecaae-f81a-4e90-9d81-c74084f06ab7.png)

**Is there anything you'd like reviewers to focus on?**
The problem is scrollbar is taking width out of the container. But if the scrollbar is absent, it will break styles once again. I tried to use clientHeight и scrollHeight properties, but because we use the infinite scroll component, it doesn't work as expected. Heights will be equal at the start and change only after downloading new data using pagination, so I cannot find when the scrollbar appears. That's why I changed styles, so that scrollbar appears always.
**How Has This Been Tested?**
<!-- ignore-task-list-start -->
- [X] Manually

<!-- ignore-task-list-end -->

**Checklist**
- [X] I have performed a self-review of my own code

Check out [Contributing](https://github.com/opendatadiscovery/odd-platform/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/opendatadiscovery/odd-platform/blob/main/CODE_OF_CONDUCT.md)