### PR TITLE
Start UI locally from scratch

### DIFF
--- a/odd-platform-ui/.env.example
+++ b/odd-platform-ui/.env.example
@@ -1,0 +1,1 @@
+VITE_DEV_PROXY=http://localhost:8080/

--- a/odd-platform-ui/.gitignore
+++ b/odd-platform-ui/.gitignore
@@ -14,6 +14,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/odd-platform-ui/README.md
+++ b/odd-platform-ui/README.md
@@ -11,9 +11,15 @@ In the project directory, you can run:
 Installs project dependencies
 
 ### `npm run generate`
-Generates an openApi client in `src/generated-sources` from API specification `prospectlog-specification//openapi.yml`
+Generates an openApi client in `src/generated-sources` from API specification [odd-platform-specification/openapi.yaml](../odd-platform-specification/openapi.yaml)
+
+### `cp .env.example .env`
+Initializes dev environment
 
 ## Run application in dev mode
+
+### `npm run start:API`
+Runs the api with preseeded(demo) data
 
 ### `npm start`
 

--- a/odd-platform-ui/package.json
+++ b/odd-platform-ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "start": "vite",
+    "start:API": "docker-compose -f ../docker/demo.yaml up -d odd-platform-enricher",
     "build-only": "vite build",
     "clean": "rm -rf ./src/generated-sources",
     "build": "npm run generate && tsc --noEmit && vite build",


### PR DESCRIPTION
**What changes did you make?** (Give an overview)

Updated README regards initialization and starting local development steps.

**Is there anything you'd like reviewers to focus on?**

Just an idea. Would be great to have a separate docker compose file for running local instance of the platform with preseeded data instead of using of demo example.

**How to test**
Try to run UI locally from the scratch using README.