### PR TITLE
Extend `gradle clean` task with deleting generated API models for UI

### DIFF
--- a/odd-platform-ui/build.gradle
+++ b/odd-platform-ui/build.gradle
@@ -22,6 +22,10 @@ jar {
     from buildUI into 'static'
 }
 
+clean.doFirst {
+    delete "${project.projectDir}/src/generated-sources"
+}
+
 sonarqube {
     properties {
         property "sonar.projectKey", "odd-platform_frontend"


### PR DESCRIPTION
closes #781 