### PR TITLE
Update workflows with latest versions of actions which runs on Node 16

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "main"
+      - 'main'
 
 concurrency: main_build
 
@@ -13,7 +13,7 @@ jobs:
     env:
       REGISTRY: 436866023604.dkr.ecr.eu-central-1.amazonaws.com
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: unfor19/install-aws-cli-action@v1
@@ -25,17 +25,17 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v1.3.3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
       - name: Cache local Gradle dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -49,10 +49,10 @@ jobs:
           CI: false
         run: ./gradlew test jib --no-daemon --image ${{ env.REGISTRY }}/${{ github.event.repository.name }} --scan -Pversion=ci-${GITHUB_SHA::6} -Penv=prod -PmultiArchContainerBuild=false
   update_tag:
-    needs: ["images"]
+    needs: ['images']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           repository: provectus/environment-state
           token: ${{ secrets.ODD_GIT_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
           git commit --allow-empty -m "update tag"
           git push
   argocd_sync:
-    needs: ["update_tag"]
+    needs: ['update_tag']
     runs-on: ubuntu-latest
     steps:
       - name: Install ArgoCD CLI

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -25,7 +25,7 @@ jobs:
       version: ${{steps.get-version.outputs.version}}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Check version
@@ -44,7 +44,7 @@ jobs:
           fi
           echo ::set-output name=version::${VERSION}
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/run-playwright-tests.yml
+++ b/.github/workflows/run-playwright-tests.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18.x'
       - name: Install dependencies
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '18.x'
       - name: Start containers
@@ -49,7 +49,7 @@ jobs:
           cd tests
           npm run test:ci
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/run-pr-tests.yaml
+++ b/.github/workflows/run-pr-tests.yaml
@@ -2,7 +2,7 @@ name: PR build
 on:
   workflow_dispatch:
   pull_request:
-    types: [ 'opened', 'edited', 'reopened', 'synchronize' ]
+    types: ['opened', 'edited', 'reopened', 'synchronize']
 
 permissions:
   checks: write
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Cache local Gradle dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -49,6 +49,6 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          files: "odd-platform-api/build/test-results/**/*.xml"
+          files: 'odd-platform-api/build/test-results/**/*.xml'
           check_name: Test Results
           comment_mode: create new

--- a/.github/workflows/sonar-backend.yaml
+++ b/.github/workflows/sonar-backend.yaml
@@ -2,41 +2,41 @@ name: SonarCloud Scan for backend
 on:
   push:
     branches:
-      - "main"
+      - 'main'
   pull_request_target:
-    types: [ "opened", "edited", "reopened", "synchronize" ]
+    types: ['opened', 'edited', 'reopened', 'synchronize']
     paths:
-      - "odd-platform-api/**"
-      - "build.gradle"
+      - 'odd-platform-api/**'
+      - 'build.gradle'
 
 jobs:
   images:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: unfor19/install-aws-cli-action@v1
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -46,7 +46,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Node cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: odd-platform-ui/.npm
           key: ${{ runner.os }}-shared-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/sonar-frontend.yaml
+++ b/.github/workflows/sonar-frontend.yaml
@@ -2,41 +2,41 @@ name: SonarCloud Scan for frontend
 on:
   push:
     branches:
-      - "main"
+      - 'main'
   pull_request_target:
-    types: [ "opened", "edited", "reopened", "synchronize" ]
+    types: ['opened', 'edited', 'reopened', 'synchronize']
     paths:
-      - "odd-platform-ui/**"
-      - "build.gradle"
+      - 'odd-platform-ui/**'
+      - 'build.gradle'
 
 jobs:
   images:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
       - uses: unfor19/install-aws-cli-action@v1
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '14'
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -46,7 +46,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Node cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: odd-platform-ui/.npm
           key: ${{ runner.os }}-shared-node-${{ hashFiles('**/package-lock.json') }}
@@ -57,7 +57,7 @@ jobs:
         env:
           GENERATE_SOURCEMAP: false
           CI: false
-          JAVA_OPTS: "-Xms2048m -Xmx2048m"
+          JAVA_OPTS: '-Xms2048m -Xmx2048m'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew -Penv=prod -p odd-platform-ui clean sonarqube --info


### PR DESCRIPTION
**What changes did you make?** (Give an overview)

- Update workflows with the latest versions of actions that run on Node 16  (to fix deprecation warnings in GitHub Actions).
  More info: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

**Is there anything you'd like reviewers to focus on?**

1. Please keep in mind that I was able to verify my changes only in the following files:
    - `.github/workflows/run-playwright-tests.yml`
    - `.github/workflows/run-pr-tests.yaml`

    because those workflows were triggered for this PR.
    
1. Changes in the following files are NOT tested (because I'm not sure how to trigger them): 
    - `.github/workflows/main-build.yaml`
    - `.github/workflows/release-build.yaml`
    - `.github/workflows/sonar-backend.yaml`
    - `.github/workflows/sonar-frontend.yaml`
    
    So there is a chance that my changes could cause some problems after triggering these workflows.
    I can revert my changes if we need to be 100% sure that nothing will be broken.
    
1. Please keep in mind that we still have 2 unresolved warning messages that need to be addressed (Pls see them in [results](https://github.com/opendatadiscovery/odd-platform/actions/runs/3377476004)).

**How to test**
- check job results