### PR TITLE
Check formatting in CI

### DIFF
--- a/.github/workflows/run-playwright-tests.yml
+++ b/.github/workflows/run-playwright-tests.yml
@@ -22,6 +22,25 @@ jobs:
           cd tests
           npm run lint:ci
 
+  format-check:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - name: Install dependencies
+        run: |
+          cd tests
+          npm ci
+      - name: Check formatting
+        run: |
+          cd tests
+          npm run format:check
+
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/tests/features/owners/add-owner.spec.ts
+++ b/tests/features/owners/add-owner.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from '../../config/test-base';
 
 test.describe('Owners', () => {
-  test('Add new Owner', async ({workerId, steps: { pages }, page }) => {
+  test('Add new Owner', async ({ workerId, steps: { pages }, page }) => {
     const ownerName = `Test_ownerName + ${workerId}`;
 
     await test.step('I open Owners page', async () => {

--- a/tests/package.json
+++ b/tests/package.json
@@ -20,6 +20,7 @@
     "lint": "eslint .",
     "lint:ci": "npx eslint --quiet .",
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "lint:fix": "eslint --fix . && npm run format",
     "prepare": "cd ../ && husky install ./tests/.husky"
   },


### PR DESCRIPTION
**What changes did you make?**
- Run prettier in CI to check formatting issues 

**Is there anything you'd like reviewers to focus on?**
- n/a

**How to test**
- check the `format:check` job in GitHub Actions.
   - the job will pass if the code has no formatting issues  
   (See example: https://ibb.co/RjYvHXm)
   - the job will fail with an error if the code has formatting issues 
   (See example: https://ibb.co/4f4zZcC)


NOTE: 
- Command for fixing formatting issues (`npm run format`) already mentioned in the [tests/README.md](https://github.com/opendatadiscovery/odd-platform/blob/2a6b870/tests/README.md#useful-commands).