### PR TITLE
Fix concurrent modification error in tests and run tests in parallel (4 threads)

### DIFF
--- a/tests/features/activity/activity.spec.ts
+++ b/tests/features/activity/activity.spec.ts
@@ -47,6 +47,7 @@ test.describe('Check filters', () => {
     });
     /**
      * /project/1/test-cases/144
+     * #concurrentModificationIssue (See more info below)
      */
     test(`Display an expected item with filter Owner`, async ({ workerId, steps: { pages } }) => {
       const ownerName7 = `ownerName7${workerId}`;
@@ -55,6 +56,16 @@ test.describe('Check filters', () => {
         await pages.topPanel.clickTab('Catalog');
         await pages.catalog.searchBy(entityNameWithAlphabeticChars);
         await pages.catalog.clickOnListItem(entityNameWithAlphabeticChars);
+        /**
+         * 'Book_ETL_aqa' replaced with other data entity name because of concurrent modification error.
+         *
+         * This error happens in ODD platform when we are trying to create owner for the same data entity at the same time.
+         * One way to get rid of this problem: do not create different owners for the same data entity at the same time.
+         * Note that there are other tests that create owners for this entity. All of these tests are located
+         * inside the following test file "search_in_data_entity.spec.ts"
+         * (You can find these tests by the keyword "#concurrentModificationIssue").
+         * These tests run sequentially with respect to each other in a parallel test run, so we can use the same data entity for them.
+         */
         await pages.overview.createOwner(ownerName7, ownerTitle7);
         await pages.topPanel.clickTab('Activity');
         await pages.activity.ownerFilter.set(ownerName7);

--- a/tests/features/search/search_in_data_entity.spec.ts
+++ b/tests/features/search/search_in_data_entity.spec.ts
@@ -97,6 +97,7 @@ test.describe('Search by data in data-entity in the Catalog', () => {
   });
   /**
    * /project/1/test-cases/118
+   * #concurrentModificationIssue
    */
   test(`Display an expected item with expression in owner's name`, async ({
     workerId,
@@ -105,16 +106,17 @@ test.describe('Search by data in data-entity in the Catalog', () => {
     const ownerName4 = `ownerName4${workerId}`;
     const ownerTitle4 = `ownerTitle4${workerId}`;
     await test.step(`When filling a valid expression in the search input`, async () => {
-      await pages.catalog.searchBy(entityNameWithAlphabeticChars);
-      await pages.catalog.clickOnListItem(entityNameWithAlphabeticChars);
+      await pages.catalog.searchBy(entityWithStructure);
+      await pages.catalog.clickOnListItem(entityWithStructure);
       await pages.overview.createOwner(ownerName4, ownerTitle4);
       await pages.topPanel.clickTab('Catalog');
       await pages.catalog.searchBy(ownerName4);
-      expect(await pages.catalog.isListItemVisible(entityNameWithAlphabeticChars)).toBeTruthy();
+      expect(await pages.catalog.isListItemVisible(entityWithStructure)).toBeTruthy();
     });
   });
   /**
    * /project/1/test-cases/119
+   * #concurrentModificationIssue
    */
   test(`Display an expected item with expression in name and owner`, async ({
     workerId,
@@ -133,6 +135,7 @@ test.describe('Search by data in data-entity in the Catalog', () => {
   });
   /**
    * /project/1/test-cases/120
+   * #concurrentModificationIssue
    */
   test(`Display an expected item with expression in "about" field and owner`, async ({
     workerId,
@@ -175,6 +178,7 @@ test.describe('Search by data in data-entity in the Catalog', () => {
   });
   /**
    * /project/1/test-cases/125
+   * #concurrentModificationIssue
    */
   test(`Display an expected item with expression in owner's title`, async ({
     workerId,

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -28,7 +28,7 @@ const config: PlaywrightTestConfig = {
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   outputDir: './test-results',


### PR DESCRIPTION
**What changes did you make?**
- Fixed concurrent modification error in the test (by creating an owner for another data entity)
- Parallelized tests: 4 workers used

**Is there anything you'd like reviewers to focus on?**
- The time to run the test suite in CI should decrease several times