### PR TITLE
Playwright | Enable the "github" reporter to get automatic failure annotations in GitHub actions

### DIFF
--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -30,7 +30,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: process.env.CI ? [['github'], ['html']] : 'html',
   outputDir: './test-results',
   // reporter: [['list', { printSteps: false }], ['./tests/config/allure-reporter.ts']],
   // repeatEach: 8, // <-- use this to check stability

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -26,7 +26,7 @@ const config: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
**What changes did you make?** (Give an overview)
- Enable the built-in `github` reporter to get automatic failure annotations when running tests in GitHub actions.
  - Documentation: https://playwright.dev/docs/test-reporters#github-actions-annotations

**Is there anything you'd like reviewers to focus on?**

**How to test**
- Annotations displayed in multiple places:
  1. in the code during the PR review
  (See example commit: https://github.com/opendatadiscovery/odd-platform/commit/aa0db995; See [screenshot](https://ibb.co/4sMZFr7))
  2. in the "Summary" section of the run in GitHub Actions
  (See [link](https://github.com/opendatadiscovery/odd-platform/actions/runs/3890550202); See [screenshot](https://ibb.co/gmFDDNt))