### PR TITLE
chore: minor css fixes for roles and polices managment page

### DIFF
--- a/odd-platform-ui/pnpm-lock.yaml
+++ b/odd-platform-ui/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   glob-parent@<5.1.2: '>=5.1.2'
 
@@ -7706,3 +7702,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/odd-platform-ui/src/components/Management/PolicyList/PolicyItem/PolicyItem.tsx
+++ b/odd-platform-ui/src/components/Management/PolicyList/PolicyItem/PolicyItem.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Grid, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
 import { deletePolicy, deleteRole } from 'redux/thunks';
 import { Permission, type Policy } from 'generated-sources';
 import { Button, ConfirmationDialog } from 'components/shared/elements';
@@ -7,7 +8,6 @@ import { DeleteIcon, EditIcon } from 'components/shared/icons';
 import { usePermissions } from 'lib/hooks';
 import { useAppDispatch } from 'redux/lib/hooks';
 import { WithPermissions } from 'components/shared/contexts';
-import { useTranslation } from 'react-i18next';
 import * as S from './PolicyItemStyles';
 
 interface PolicyItemProps {
@@ -22,7 +22,7 @@ const PolicyItem: React.FC<PolicyItemProps> = ({ policyId, name }) => {
 
   const isAdministrator = name === 'Administrator';
 
-  const handleDelete = React.useCallback(
+  const handleDelete = useCallback(
     () => dispatch(deletePolicy({ policyId })),
     [policyId, deleteRole]
   );
@@ -35,7 +35,7 @@ const PolicyItem: React.FC<PolicyItemProps> = ({ policyId, name }) => {
         </Typography>
       </Grid>
       <Grid item container lg={6.73} flexWrap='nowrap' />
-      <Grid item lg={1.74}>
+      <Grid item lg={2}>
         <S.ActionsContainer container item>
           <Button
             text={

--- a/odd-platform-ui/src/components/Management/RolesList/RoleItem/RoleItem.tsx
+++ b/odd-platform-ui/src/components/Management/RolesList/RoleItem/RoleItem.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Grid, Typography } from '@mui/material';
+import TruncateMarkup from 'react-truncate-markup';
+import { useTranslation } from 'react-i18next';
 import { deleteRole } from 'redux/thunks';
 import { Permission, type Role } from 'generated-sources';
 import { Button, ConfirmationDialog } from 'components/shared/elements';
 import { DeleteIcon, EditIcon } from 'components/shared/icons';
 import { useAppDispatch } from 'redux/lib/hooks';
-import TruncateMarkup from 'react-truncate-markup';
 import { WithPermissions } from 'components/shared/contexts';
-import { useTranslation } from 'react-i18next';
 import RoleForm from '../RoleForm/RoleForm';
 import * as S from './RoleItemStyles';
 
@@ -24,7 +24,7 @@ const RoleItem: React.FC<RoleItemProps> = ({ roleId, name, policies }) => {
   const isUser = name === 'User';
   const isAdministrator = name === 'Administrator';
 
-  const handleDelete = React.useCallback(
+  const handleDelete = useCallback(
     () => dispatch(deleteRole({ roleId })),
     [roleId, deleteRole]
   );
@@ -49,7 +49,7 @@ const RoleItem: React.FC<RoleItemProps> = ({ roleId, name, policies }) => {
           </div>
         </TruncateMarkup>
       </Grid>
-      <Grid item lg={1.74}>
+      <Grid item lg={2}>
         <S.ActionsContainer container item>
           <WithPermissions
             permissionTo={Permission.ROLE_UPDATE}


### PR DESCRIPTION
There were a few minor markup collisions
**Before:**
<img width="1694" alt="Screenshot 2023-09-29 at 16 33 08" src="https://github.com/opendatadiscovery/odd-platform/assets/2155083/cfe02467-0a7b-492c-956c-5378302b4c8b">
<img width="1693" alt="Screenshot 2023-09-29 at 16 33 19" src="https://github.com/opendatadiscovery/odd-platform/assets/2155083/8e884053-143e-4cca-bbdd-db9cd1d82b66">

**After:**
<img width="1693" alt="Screenshot 2023-09-29 at 16 33 32" src="https://github.com/opendatadiscovery/odd-platform/assets/2155083/418c05e7-11a6-4393-af9c-55c3463c9937">

