### PR TITLE
(bugfix): correct rendering terms' markdown on dataset structure page

### DIFF
--- a/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureOverview/DatasetStructureView/DatasetFieldOverview/DatasetFieldTerms/TermItem/TermItem.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureOverview/DatasetStructureView/DatasetFieldOverview/DatasetFieldTerms/TermItem/TermItem.tsx
@@ -2,7 +2,12 @@ import React, { type FC, useCallback } from 'react';
 import { Box } from '@mui/material';
 import { Permission, type TermRef } from 'generated-sources';
 import { WithPermissions } from 'components/shared/contexts';
-import { Button, CollapsibleInfoContainer, InfoItem } from 'components/shared/elements';
+import {
+  Button,
+  CollapsibleInfoContainer,
+  InfoItem,
+  Markdown,
+} from 'components/shared/elements';
 import { DeleteIcon, LinkedTermIcon } from 'components/shared/icons';
 import { useAppPaths, useDeleteDatasetFieldTerm } from 'lib/hooks';
 
@@ -49,7 +54,7 @@ const TermItem: FC<TermItemProps> = ({
       }
       info={
         <CollapsibleInfoContainer
-          content={<>{definition}</>}
+          content={<Markdown value={definition} />}
           actions={
             !isDescriptionLink ? (
               <WithPermissions permissionTo={Permission.DATASET_FIELD_DELETE_TERM}>

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewTerms/TermItem/TermItem.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewTerms/TermItem/TermItem.tsx
@@ -41,7 +41,7 @@ const TermItem: React.FC<TermItemProps> = ({
             {linkedTerm.isDescriptionLink && <LinkedTermIcon />}
           </Box>
           <S.TermDefinition variant='subtitle2'>
-            {linkedTerm.term.definition}
+            {linkedTerm.term.namespace.name}
           </S.TermDefinition>
         </Grid>
         {!linkedTerm.isDescriptionLink && !isStatusDeleted && (

--- a/odd-platform-ui/src/components/shared/elements/forms/AssignTermForm/AssignTermForm.tsx
+++ b/odd-platform-ui/src/components/shared/elements/forms/AssignTermForm/AssignTermForm.tsx
@@ -6,6 +6,7 @@ import Button from 'components/shared/elements/Button/Button';
 import TermsAutocomplete from 'components/shared/elements/Autocomplete/TermsAutocomplete/TermsAutocomplete';
 import type { TermRef } from 'generated-sources';
 import DialogWrapper from 'components/shared/elements/DialogWrapper/DialogWrapper';
+import Markdown from 'components/shared/elements/Markdown/Markdown';
 
 interface AssignTermFormData {
   termId: number;
@@ -75,7 +76,7 @@ const AssignTermForm: FC<AssignTermFormProps> = ({
             <Typography variant='body2' color='texts.secondary' component='span'>
               {t('Definition')}:
             </Typography>
-            {selectedTerm.definition}
+            <Markdown value={selectedTerm.definition} />
           </Grid>
         </>
       )}

--- a/odd-platform-ui/src/lib/hooks/api/terms.ts
+++ b/odd-platform-ui/src/lib/hooks/api/terms.ts
@@ -1,19 +1,15 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { termApi } from 'lib/api';
-import type { TermApiGetTermByNamespaceAndNameRequest, TermRef } from 'generated-sources';
+import type { TermApiGetTermByNamespaceAndNameRequest } from 'generated-sources';
 import type { AppError } from 'lib/errorHandling';
 
 export function useGetTermByNamespaceAndName() {
   const queryClient = useQueryClient();
 
-  return async ({
-    namespaceName,
-    termName,
-  }: TermApiGetTermByNamespaceAndNameRequest): Promise<TermRef | AppError> => {
+  return async ({ namespaceName, termName }: TermApiGetTermByNamespaceAndNameRequest) => {
     try {
-      const params = { namespaceName, termName };
-      return await queryClient.fetchQuery(['term', namespaceName, termName], () =>
-        termApi.getTermByNamespaceAndName(params)
+      return await queryClient.fetchQuery(['terms', namespaceName, termName], () =>
+        termApi.getTermByNamespaceAndName({ namespaceName, termName })
       );
     } catch (error) {
       return error as AppError;


### PR DESCRIPTION
correct rendering terms' markdown on dataset structure page. resolves https://github.com/opendatadiscovery/odd-platform/issues/1464

<img width="1616" alt="Screenshot 2023-10-11 at 18 35 37" src="https://github.com/opendatadiscovery/odd-platform/assets/2155083/c294fefc-3935-4cba-941c-92ddb5897026">
