### PR TITLE
Dependencies: upgrade react-query from 4 to 5

### DIFF
--- a/odd-platform-ui/package.json
+++ b/odd-platform-ui/package.json
@@ -45,7 +45,7 @@
     "@mui/system": "^5.14.4",
     "@mui/x-date-pickers": "^5.0.20",
     "@reduxjs/toolkit": "^1.9.5",
-    "@tanstack/react-query": "^4.32.6",
+    "@tanstack/react-query": "^5.0.5",
     "@tanstack/react-virtual": "3.0.0-beta.60",
     "@uiw/react-md-editor": "^3.23.5",
     "@visx/curve": "^3.3.0",

--- a/odd-platform-ui/pnpm-lock.yaml
+++ b/odd-platform-ui/pnpm-lock.yaml
@@ -28,8 +28,8 @@ dependencies:
     specifier: ^1.9.5
     version: 1.9.5(react-redux@8.1.2)(react@18.2.0)
   '@tanstack/react-query':
-    specifier: ^4.32.6
-    version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+    specifier: ^5.0.5
+    version: 5.0.5(react-dom@18.2.0)(react@18.2.0)
   '@tanstack/react-virtual':
     specifier: 3.0.0-beta.60
     version: 3.0.0-beta.60(react@18.2.0)
@@ -1449,15 +1449,15 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
-  /@tanstack/query-core@4.32.6:
-    resolution: {integrity: sha512-YVB+mVWENQwPyv+40qO7flMgKZ0uI41Ph7qXC2Zf1ft5AIGfnXnMZyifB2ghhZ27u+5wm5mlzO4Y6lwwadzxCA==}
+  /@tanstack/query-core@5.0.5:
+    resolution: {integrity: sha512-MThCETMkHDHTnFZHp71L+SqTtD5d6XHftFCVR1xRJdWM3qGrlQ2VCXaj0SKVcyJej2e1Opa2c7iknu1llxCDNQ==}
     dev: false
 
-  /@tanstack/react-query@4.32.6(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-AITu/IKJJJXsHHeXNBy5bclu12t08usMCY0vFC2dh9SP/w6JAk5U9GwfjOIPj3p+ATADZvxQPe8UiCtMLNeQbg==}
+  /@tanstack/react-query@5.0.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-ZG0Q4HZ0iuI8mWiZ2/MdVYPHbrmAVhMn7+gLOkxJh6zLIgCL4luSZlohzN5Xt4MjxfxxWioO1nemwpudaTsmQg==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
       react-native: '*'
     peerDependenciesMeta:
       react-dom:
@@ -1465,10 +1465,9 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@tanstack/query-core': 4.32.6
+      '@tanstack/query-core': 5.0.5
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
   /@tanstack/react-virtual@3.0.0-beta.60(react@18.2.0):

--- a/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureCompare/DatasetStructureCompare.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureCompare/DatasetStructureCompare.tsx
@@ -43,7 +43,11 @@ const DatasetStructureCompare: FC = () => {
         />
       )}
       {isLoading && <AppLoadingPage />}
-      <AppErrorPage showError={isError} offsetTop={210} error={error as ErrorState} />
+      <AppErrorPage
+        showError={isError}
+        offsetTop={210}
+        error={error as unknown as ErrorState}
+      />
       <EmptyContentPlaceholder
         isContentLoaded={isSuccess}
         isContentEmpty={!data?.structureDiffList.length}

--- a/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureOverview/DatasetStructureView/DatasetFieldOverview/DatasetFieldHeader/DatasetFieldInternalNameForm/DatasetFieldInternalNameForm.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureOverview/DatasetStructureView/DatasetFieldOverview/DatasetFieldHeader/DatasetFieldInternalNameForm/DatasetFieldInternalNameForm.tsx
@@ -21,7 +21,7 @@ const DatasetFieldInternalNameForm = ({
   const formId = 'datasetField-internal-name';
   const {
     mutateAsync: updateName,
-    isLoading: isInternalNameUpdating,
+    isPending: isInternalNameUpdating,
     isSuccess: isInternalNameUpdated,
   } = useUpdateDatasetFieldInternalName();
 

--- a/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureOverview/DatasetStructureView/DatasetFieldOverview/DatasetFieldTerms/AssignFieldTermForm/AssignFieldTermForm.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DatasetStructure/DatasetStructureOverview/DatasetStructureView/DatasetFieldOverview/DatasetFieldTerms/AssignFieldTermForm/AssignFieldTermForm.tsx
@@ -14,7 +14,7 @@ const AssignFieldTermForm: FC<AssignFieldTermFormProps> = ({
   datasetFieldId,
   handleAddTerm,
 }) => {
-  const { isLoading, isSuccess, mutateAsync: addTerm } = useAddDatasetFieldTerm();
+  const { isPending, isSuccess, mutateAsync: addTerm } = useAddDatasetFieldTerm();
 
   const onSubmit = useCallback(
     (clearState: () => void) =>
@@ -32,7 +32,7 @@ const AssignFieldTermForm: FC<AssignFieldTermFormProps> = ({
       onSubmit={onSubmit}
       openBtnEl={openBtnEl}
       handleCloseSubmittedForm={isSuccess}
-      isLoading={isLoading}
+      isLoading={isPending}
     />
   );
 };

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewAttachments/EditLinkForm/EditLinkForm.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewAttachments/EditLinkForm/EditLinkForm.tsx
@@ -18,7 +18,7 @@ const EditLinkForm: FC<EditLinkFormProps> = ({ openBtn, linkId, name, url }) => 
   const { t } = useTranslation();
   const { dataEntityId } = useAppParams();
 
-  const { mutate: updateLink, isLoading, isSuccess } = useUpdateDataEntityLink();
+  const { mutate: updateLink, isPending, isSuccess } = useUpdateDataEntityLink();
 
   const { reset, formState, handleSubmit, control } = useForm<DataEntityLinkFormData>({
     defaultValues: { name, url },
@@ -90,7 +90,7 @@ const EditLinkForm: FC<EditLinkFormProps> = ({ openBtn, linkId, name, url }) => 
       renderContent={formContent}
       renderActions={formActionButtons}
       handleCloseSubmittedForm={isSuccess}
-      isLoading={isLoading}
+      isLoading={isPending}
       clearState={clearState}
     />
   );

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewAttachments/SaveFilesForm/SaveFilesForm.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewAttachments/SaveFilesForm/SaveFilesForm.tsx
@@ -18,7 +18,7 @@ const SaveFilesForm: FC<SaveFilesFormProps> = ({ openBtn, maxSize }) => {
   const formId = 'save-files-form';
   const { dataEntityId } = useAppParams();
 
-  const { mutate: saveFile, isLoading, isSuccess } = useSaveDataEntityFile();
+  const { mutate: saveFile, isPending, isSuccess } = useSaveDataEntityFile();
 
   const [uploadedFile, setUploadedFile] = useState<Blob | undefined>(undefined);
   const { reset, handleSubmit, control } = useForm<FormData>({
@@ -92,7 +92,7 @@ const SaveFilesForm: FC<SaveFilesFormProps> = ({ openBtn, maxSize }) => {
       type='submit'
       form={formId}
       fullWidth
-      disabled={!uploadedFile || isLoading}
+      disabled={!uploadedFile || isPending}
     />
   );
 
@@ -106,7 +106,7 @@ const SaveFilesForm: FC<SaveFilesFormProps> = ({ openBtn, maxSize }) => {
       renderContent={formContent}
       renderActions={formActionButtons}
       handleCloseSubmittedForm={isSuccess}
-      isLoading={isLoading}
+      isLoading={isPending}
       clearState={clearState}
       confirmOnClose
     />

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewAttachments/SaveLinksForm/SaveLinksForm.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewAttachments/SaveLinksForm/SaveLinksForm.tsx
@@ -15,7 +15,7 @@ const SaveLinksForm: FC<SaveLinksFormProps> = ({ openBtn }) => {
   const formId = 'save-links-form';
   const { dataEntityId } = useAppParams();
 
-  const { mutate: saveLinks, isLoading, isSuccess } = useSaveDataEntityLinks();
+  const { mutate: saveLinks, isPending, isSuccess } = useSaveDataEntityLinks();
 
   const methods = useForm<DataEntityLinkListFormData>({
     defaultValues: { items: [{ name: '', url: '' }] },
@@ -87,7 +87,7 @@ const SaveLinksForm: FC<SaveLinksFormProps> = ({ openBtn }) => {
       renderContent={formContent}
       renderActions={formActionButtons}
       handleCloseSubmittedForm={isSuccess}
-      isLoading={isLoading}
+      isLoading={isPending}
       clearState={clearState}
     />
   );

--- a/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewEntityGroupItems/OverviewEntityGroupItems.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/Overview/OverviewStats/OverviewEntityGroupItems/OverviewEntityGroupItems.tsx
@@ -106,7 +106,7 @@ const OverviewEntityGroupItems: FC = () => {
                 scrollableTarget='entity-group-items-list'
                 dataLength={entities.length}
                 next={fetchNextPage}
-                hasMore={!!hasNextPage}
+                hasMore={hasNextPage}
                 loader={
                   <Grid container justifyContent='center' mt={3}>
                     <AppCircularProgress size={30} background='transparent' />

--- a/odd-platform-ui/src/components/Directory/DataSourceList/DataSourceList.tsx
+++ b/odd-platform-ui/src/components/Directory/DataSourceList/DataSourceList.tsx
@@ -106,7 +106,11 @@ const DataSourceList: FC = () => {
   return (
     <>
       {isLoading && <AppLoadingPage />}
-      <AppErrorPage showError={isError} offsetTop={210} error={error as ErrorState} />
+      <AppErrorPage
+        showError={isError}
+        offsetTop={210}
+        error={error as unknown as ErrorState}
+      />
       {dataSourceList && (
         <S.Container>
           <DirectoryBreadCrumbs />

--- a/odd-platform-ui/src/components/Directory/Directory/Directory.tsx
+++ b/odd-platform-ui/src/components/Directory/Directory/Directory.tsx
@@ -27,7 +27,11 @@ const Directory: FC = () => {
         <Typography variant='h0'>{t('Directories')}</Typography>
       </Grid>
       {isLoading && <AppLoadingPage />}
-      <AppErrorPage showError={isError} offsetTop={210} error={error as ErrorState} />
+      <AppErrorPage
+        showError={isError}
+        offsetTop={210}
+        error={error as unknown as ErrorState}
+      />
       {dataSourceTypes && (
         <ScrollableContainer $offsetY={70}>
           <Grid container mt={3} columnGap={1} rowGap={3}>

--- a/odd-platform-ui/src/components/Directory/Entities/Entities.tsx
+++ b/odd-platform-ui/src/components/Directory/Entities/Entities.tsx
@@ -60,7 +60,7 @@ const Entities: FC = () => {
       <AppErrorPage
         showError={isTypesError || isEntitiesError}
         offsetTop={210}
-        error={(typesError || entitiesError) as ErrorState}
+        error={(typesError ?? entitiesError) as ErrorState}
       />
       <S.Container>
         <DirectoryBreadCrumbs dataSourceName={dataSourceName} />
@@ -80,7 +80,7 @@ const Entities: FC = () => {
         {types && <EntitiesTabs types={types} />}
         <EntitiesList
           entities={entities}
-          hasNextPage={!!hasNextPage}
+          hasNextPage={hasNextPage}
           isEntitiesLoaded={isEntitiesLoaded}
           isContentEmpty={!total}
           fetchNextPage={fetchNextPage}

--- a/odd-platform-ui/src/components/Directory/Entities/EntitiesList/EntitiesList.tsx
+++ b/odd-platform-ui/src/components/Directory/Entities/EntitiesList/EntitiesList.tsx
@@ -1,7 +1,7 @@
 import React, { type FC } from 'react';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { Grid } from '@mui/material';
-import type { InfiniteQueryObserverResult } from '@tanstack/react-query';
+import type { InfiniteData, InfiniteQueryObserverResult } from '@tanstack/react-query';
 import {
   AppCircularProgress,
   EmptyContentPlaceholder,
@@ -19,7 +19,7 @@ interface EntitiesResultsListProps {
   isEntitiesLoaded: boolean;
   isContentEmpty: boolean;
   fetchNextPage: () => Promise<
-    InfiniteQueryObserverResult<DataSourceEntityList, ErrorState>
+    InfiniteQueryObserverResult<InfiniteData<DataSourceEntityList>, ErrorState>
   >;
 }
 

--- a/odd-platform-ui/src/components/Management/Integrations/IntegrationPreviewList/IntegrationPreviewList.tsx
+++ b/odd-platform-ui/src/components/Management/Integrations/IntegrationPreviewList/IntegrationPreviewList.tsx
@@ -26,7 +26,7 @@ const IntegrationPreviewList: FC = () => {
   const filteredIntegrations =
     data?.items.filter(integration =>
       integration.name.toLowerCase().includes(query.toLowerCase())
-    ) || [];
+    ) ?? [];
 
   return (
     <Grid container flexDirection='column' alignItems='center'>

--- a/odd-platform-ui/src/components/shared/elements/AppErrorPage/AppErrorPage.tsx
+++ b/odd-platform-ui/src/components/shared/elements/AppErrorPage/AppErrorPage.tsx
@@ -10,7 +10,6 @@ interface AppErrorPageProps {
   error?: ErrorState;
   offsetTop?: number;
 }
-
 const AppErrorPage: React.FC<AppErrorPageProps> = ({
   showError,
   error,
@@ -27,7 +26,7 @@ const AppErrorPage: React.FC<AppErrorPageProps> = ({
           </Typography>
         </Grid>
         <Grid item alignItems='center'>
-          <Typography variant='h1'>{error?.statusText || t('Unknown Error')}</Typography>
+          <Typography variant='h1'>{error?.statusText ?? t('Unknown Error')}</Typography>
           <Grid container alignItems='center'>
             <Typography variant='body1'>{t('Return to the')}</Typography>
             <Button text={t('Home Page')} to='/' buttonType='tertiary-m' />

--- a/odd-platform-ui/src/components/shared/elements/EntityStatus/StatusSettingsForm/StatusSettingsForm.tsx
+++ b/odd-platform-ui/src/components/shared/elements/EntityStatus/StatusSettingsForm/StatusSettingsForm.tsx
@@ -42,7 +42,7 @@ const StatusSettingsForm: FC<StatusSettingsFormProps> = ({
   const { add } = useAppDateTime();
   const {
     mutateAsync: updateStatus,
-    isLoading: isStatusUpdating,
+    isPending: isStatusUpdating,
     isSuccess: isStatusUpdated,
   } = useUpdateDataEntityStatus();
 

--- a/odd-platform-ui/src/index.tsx
+++ b/odd-platform-ui/src/index.tsx
@@ -29,11 +29,11 @@ declare module 'styled-components' {
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
-    onError: async e => {
-      if ((e as Error).message === '401') {
+    onError: (e: unknown) => {
+      if (e instanceof Error && e.message === '401') {
         window.location.reload();
       }
-      await showServerErrorToast(e as Response);
+      showServerErrorToast(e as Response);
     },
   }),
   defaultOptions: {
@@ -42,9 +42,7 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
     },
     mutations: {
-      async onError(e) {
-        await showServerErrorToast(e as Response);
-      },
+      onError: async (e: unknown) => await showServerErrorToast(e as Response),
     },
   },
 });

--- a/odd-platform-ui/src/lib/hooks/api/dataEntity.ts
+++ b/odd-platform-ui/src/lib/hooks/api/dataEntity.ts
@@ -24,7 +24,7 @@ export function useDataEntityMetrics({
 }: UseDataEntityMetricsProps) {
   return useQuery({
     queryKey: ['dataEntityMetrics', dataEntityId],
-    queryFn: () =>
+    queryFn: async () =>
       dataEntityApi.getDataEntityMetrics({ dataEntityId }).catch(err => {
         showServerErrorToast(err as Response, {
           additionalMessage: 'while loading metrics',
@@ -143,12 +143,9 @@ export function useGetDataEntityGroupItems({
 }
 
 export function useUpdateDataEntityStatus() {
-  return useMutation(
-    (params: DataEntityApiUpdateStatusRequest) => dataEntityApi.updateStatus(params),
-    {
-      onSuccess: () => {
-        showSuccessToast({ message: 'Status successfully updated!' });
-      },
-    }
-  );
+  return useMutation({
+    mutationFn: async (params: DataEntityApiUpdateStatusRequest) =>
+      dataEntityApi.updateStatus(params),
+    onSuccess: () => showSuccessToast({ message: 'Status successfully updated!' }),
+  });
 }

--- a/odd-platform-ui/src/lib/hooks/api/dataEntityAttachments/dataEntityFiles.ts
+++ b/odd-platform-ui/src/lib/hooks/api/dataEntityAttachments/dataEntityFiles.ts
@@ -74,9 +74,9 @@ export function useSaveDataEntityFile() {
         uploadId,
       });
     },
-    onSuccess: async () => {
+    onSuccess: () => {
       showSuccessToast({ message: 'File successfully saved!' });
-      await client.invalidateQueries(['dataEntityAttachments']);
+      client.invalidateQueries({ queryKey: ['dataEntityAttachments'] });
     },
   });
 }
@@ -100,7 +100,7 @@ export function useDeleteDataEntityFile() {
       dataEntityAttachmentApi.deleteFile(params),
     onSuccess: async () => {
       showSuccessToast({ message: 'File successfully deleted!' });
-      await client.invalidateQueries(['dataEntityAttachments']);
+      await client.invalidateQueries({ queryKey: ['dataEntityAttachments'] });
     },
   });
 }

--- a/odd-platform-ui/src/lib/hooks/api/dataEntityAttachments/dataEntityFiles.ts
+++ b/odd-platform-ui/src/lib/hooks/api/dataEntityAttachments/dataEntityFiles.ts
@@ -52,8 +52,8 @@ interface UseSaveDataEntityFileParams {
 export function useSaveDataEntityFile() {
   const client = useQueryClient();
 
-  return useMutation(
-    async ({ dataEntityId, file }: UseSaveDataEntityFileParams) => {
+  return useMutation({
+    mutationFn: async ({ dataEntityId, file }: UseSaveDataEntityFileParams) => {
       const dataEntityUploadFormData = { fileName: file.name };
       const initialUploadParams = { dataEntityId, dataEntityUploadFormData };
       const { id: uploadId } = await dataEntityAttachmentApi.initiateFileUpload(
@@ -74,13 +74,11 @@ export function useSaveDataEntityFile() {
         uploadId,
       });
     },
-    {
-      onSuccess: () => {
-        showSuccessToast({ message: 'File successfully saved!' });
-        client.invalidateQueries(['dataEntityAttachments']);
-      },
-    }
-  );
+    onSuccess: async () => {
+      showSuccessToast({ message: 'File successfully saved!' });
+      await client.invalidateQueries(['dataEntityAttachments']);
+    },
+  });
 }
 
 export function useDownloadDataEntityFile({
@@ -97,16 +95,14 @@ export function useDownloadDataEntityFile({
 export function useDeleteDataEntityFile() {
   const client = useQueryClient();
 
-  return useMutation(
-    (params: DataEntityAttachmentApiDeleteFileRequest) =>
+  return useMutation({
+    mutationFn: (params: DataEntityAttachmentApiDeleteFileRequest) =>
       dataEntityAttachmentApi.deleteFile(params),
-    {
-      onSuccess: () => {
-        showSuccessToast({ message: 'File successfully deleted!' });
-        client.invalidateQueries(['dataEntityAttachments']);
-      },
-    }
-  );
+    onSuccess: async () => {
+      showSuccessToast({ message: 'File successfully deleted!' });
+      await client.invalidateQueries(['dataEntityAttachments']);
+    },
+  });
 }
 
 export function useGetUploadOptions({

--- a/odd-platform-ui/src/lib/hooks/api/dataEntityAttachments/dataEntityLinks.ts
+++ b/odd-platform-ui/src/lib/hooks/api/dataEntityAttachments/dataEntityLinks.ts
@@ -34,7 +34,7 @@ export function useSaveDataEntityLinks() {
       await dataEntityAttachmentApi.saveLinks(params),
     onSuccess: async () => {
       showSuccessToast({ message: 'Links successfully saved!' });
-      await client.invalidateQueries(['dataEntityAttachments']);
+      await client.invalidateQueries({ queryKey: ['dataEntityAttachments'] });
     },
   });
 }
@@ -47,7 +47,7 @@ export function useUpdateDataEntityLink() {
       await dataEntityAttachmentApi.updateLink(params),
     onSuccess: async () => {
       showSuccessToast({ message: 'Link successfully updated!' });
-      await client.invalidateQueries(['dataEntityAttachments']);
+      await client.invalidateQueries({ queryKey: ['dataEntityAttachments'] });
     },
   });
 }
@@ -60,7 +60,7 @@ export function useDeleteDataEntityLink() {
       dataEntityAttachmentApi.deleteLink(params),
     onSuccess: async () => {
       showSuccessToast({ message: 'Link successfully deleted!' });
-      await client.invalidateQueries(['dataEntityAttachments']);
+      await client.invalidateQueries({ queryKey: ['dataEntityAttachments'] });
     },
   });
 }

--- a/odd-platform-ui/src/lib/hooks/api/dataEntityAttachments/dataEntityLinks.ts
+++ b/odd-platform-ui/src/lib/hooks/api/dataEntityAttachments/dataEntityLinks.ts
@@ -19,56 +19,48 @@ export function useDataEntityAttachments({
     DataEntityAttachments,
     ErrorState,
     Array<DataEntityFile | DataEntityLink>
-  >(
-    ['dataEntityAttachments'],
-    () => dataEntityAttachmentApi.getAttachments({ dataEntityId }),
-    {
-      select: data => [...data.files, ...data.links],
-    }
-  );
+  >({
+    queryKey: ['dataEntityAttachments'],
+    queryFn: () => dataEntityAttachmentApi.getAttachments({ dataEntityId }),
+    select: data => [...data.files, ...data.links],
+  });
 }
 
 export function useSaveDataEntityLinks() {
   const client = useQueryClient();
 
-  return useMutation(
-    (params: DataEntityAttachmentApiSaveLinksRequest) =>
-      dataEntityAttachmentApi.saveLinks(params),
-    {
-      onSuccess: () => {
-        showSuccessToast({ message: 'Links successfully saved!' });
-        client.invalidateQueries(['dataEntityAttachments']);
-      },
-    }
-  );
+  return useMutation({
+    mutationFn: async (params: DataEntityAttachmentApiSaveLinksRequest) =>
+      await dataEntityAttachmentApi.saveLinks(params),
+    onSuccess: async () => {
+      showSuccessToast({ message: 'Links successfully saved!' });
+      await client.invalidateQueries(['dataEntityAttachments']);
+    },
+  });
 }
 
 export function useUpdateDataEntityLink() {
   const client = useQueryClient();
 
-  return useMutation(
-    (params: DataEntityAttachmentApiUpdateLinkRequest) =>
-      dataEntityAttachmentApi.updateLink(params),
-    {
-      onSuccess: () => {
-        showSuccessToast({ message: 'Link successfully updated!' });
-        client.invalidateQueries(['dataEntityAttachments']);
-      },
-    }
-  );
+  return useMutation({
+    mutationFn: async (params: DataEntityAttachmentApiUpdateLinkRequest) =>
+      await dataEntityAttachmentApi.updateLink(params),
+    onSuccess: async () => {
+      showSuccessToast({ message: 'Link successfully updated!' });
+      await client.invalidateQueries(['dataEntityAttachments']);
+    },
+  });
 }
 
 export function useDeleteDataEntityLink() {
   const client = useQueryClient();
 
-  return useMutation(
-    (params: DataEntityAttachmentApiDeleteLinkRequest) =>
+  return useMutation({
+    mutationFn: (params: DataEntityAttachmentApiDeleteLinkRequest) =>
       dataEntityAttachmentApi.deleteLink(params),
-    {
-      onSuccess: () => {
-        showSuccessToast({ message: 'Link successfully deleted!' });
-        client.invalidateQueries(['dataEntityAttachments']);
-      },
-    }
-  );
+    onSuccess: async () => {
+      showSuccessToast({ message: 'Link successfully deleted!' });
+      await client.invalidateQueries(['dataEntityAttachments']);
+    },
+  });
 }

--- a/odd-platform-ui/src/lib/hooks/api/datasetField.ts
+++ b/odd-platform-ui/src/lib/hooks/api/datasetField.ts
@@ -16,9 +16,9 @@ export function useDataSetFieldMetrics({ datasetFieldId }: UseDataEntityMetricsP
     queryFn: async () =>
       datasetFieldApiClient
         .getDatasetFieldMetrics({ datasetFieldId })
-        .catch((err: Response) => {
-          showServerErrorToast(err, { additionalMessage: 'while loading field metrics' });
-        }),
+        .catch(err =>
+          showServerErrorToast(err, { additionalMessage: 'while loading field metrics' })
+        ),
     retry: false,
     refetchOnWindowFocus: false,
   });

--- a/odd-platform-ui/src/lib/hooks/api/datasetField.ts
+++ b/odd-platform-ui/src/lib/hooks/api/datasetField.ts
@@ -13,12 +13,12 @@ interface UseDataEntityMetricsProps {
 export function useDataSetFieldMetrics({ datasetFieldId }: UseDataEntityMetricsProps) {
   return useQuery({
     queryKey: ['dataSetFieldMetrics', datasetFieldId],
-    queryFn: () =>
-      datasetFieldApiClient.getDatasetFieldMetrics({ datasetFieldId }).catch(err => {
-        showServerErrorToast(err as Response, {
-          additionalMessage: 'while loading field metrics',
-        });
-      }),
+    queryFn: async () =>
+      datasetFieldApiClient
+        .getDatasetFieldMetrics({ datasetFieldId })
+        .catch((err: Response) => {
+          showServerErrorToast(err, { additionalMessage: 'while loading field metrics' });
+        }),
     retry: false,
     refetchOnWindowFocus: false,
   });
@@ -30,43 +30,31 @@ interface UseAddDatasetFieldTermParams {
 }
 
 export function useAddDatasetFieldTerm() {
-  return useMutation(
-    ({ datasetFieldId, termId }: UseAddDatasetFieldTermParams) => {
-      const params = { datasetFieldId, datasetFieldTermFormData: { termId } };
-
-      return datasetFieldApiClient.addDatasetFieldTerm(params);
-    },
-    {
-      onSuccess: () => {
-        showSuccessToast({ message: 'Term successfully added!' });
-      },
-    }
-  );
+  return useMutation({
+    mutationFn: async ({ termId, datasetFieldId }: UseAddDatasetFieldTermParams) =>
+      datasetFieldApiClient.addDatasetFieldTerm({
+        datasetFieldId,
+        datasetFieldTermFormData: { termId },
+      }),
+    onSuccess: () => showSuccessToast({ message: 'Term successfully added!' }),
+  });
 }
 
 export function useDeleteDatasetFieldTerm() {
-  return useMutation(
-    async (params: DatasetFieldApiDeleteTermFromDatasetFieldRequest) => {
+  return useMutation({
+    mutationFn: async (params: DatasetFieldApiDeleteTermFromDatasetFieldRequest) => {
       await datasetFieldApiClient.deleteTermFromDatasetField(params);
 
       return params.termId;
     },
-    {
-      onSuccess: () => {
-        showSuccessToast({ message: 'Term successfully deleted!' });
-      },
-    }
-  );
+    onSuccess: () => showSuccessToast({ message: 'Term successfully deleted!' }),
+  });
 }
 
 export function useUpdateDatasetFieldInternalName() {
-  return useMutation(
-    async (params: DatasetFieldApiUpdateDatasetFieldInternalNameRequest) =>
+  return useMutation({
+    mutationFn: async (params: DatasetFieldApiUpdateDatasetFieldInternalNameRequest) =>
       datasetFieldApiClient.updateDatasetFieldInternalName(params),
-    {
-      onSuccess: () => {
-        showSuccessToast({ message: 'Internal name successfully updated!' });
-      },
-    }
-  );
+    onSuccess: () => showSuccessToast({ message: 'Internal name successfully updated!' }),
+  });
 }

--- a/odd-platform-ui/src/lib/hooks/api/directory.ts
+++ b/odd-platform-ui/src/lib/hooks/api/directory.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { type InfiniteData, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { directoryApi } from 'lib/api';
 import type {
   DirectoryApiGetDatasourceEntitiesRequest,
@@ -47,9 +47,15 @@ export function useGetDataSourceEntities({
   typeId,
   enabled,
 }: UseGetDataSourceEntities) {
-  return useInfiniteQuery<DataSourceEntityList, ErrorState, DataSourceEntityList>({
+  return useInfiniteQuery<
+    DataSourceEntityList,
+    ErrorState,
+    InfiniteData<DataSourceEntityList>,
+    ['directoryDataSourceEntities', Omit<UseGetDataSourceEntities, 'enabled'>],
+    number
+  >({
     queryKey: ['directoryDataSourceEntities', { dataSourceId, size, typeId }],
-    queryFn: async ({ pageParam = 1 }) => {
+    queryFn: async ({ pageParam }) => {
       const response = await directoryApi.getDatasourceEntities({
         dataSourceId,
         size,
@@ -73,6 +79,7 @@ export function useGetDataSourceEntities({
         },
       };
     },
+    initialPageParam: 1,
     getNextPageParam: lastPage => lastPage.entities.pageInfo.nextPage,
     enabled,
   });

--- a/odd-platform-ui/src/lib/hooks/api/integration.ts
+++ b/odd-platform-ui/src/lib/hooks/api/integration.ts
@@ -13,33 +13,34 @@ export function useIntegrationPreviews() {
     { items: GeneratedIntegrationPreview[] },
     ErrorState,
     { items: IntegrationPreview[] }
-  >(['integrationPreviews'], () => integrationApi.getIntegrationPreviews());
+  >({
+    queryKey: ['integrationPreviews'],
+    queryFn: () => integrationApi.getIntegrationPreviews(),
+  });
 }
 
 export function useIntegration({ integrationId }: IntegrationApiGetIntegrationRequest) {
-  return useQuery<GeneratedIntegration, ErrorState, Integration>(
-    ['integration', integrationId],
-    () => integrationApi.getIntegration({ integrationId }),
-    {
-      select: ({ id, installed, name, description, contentBlocks }) => {
-        const contentByTitle = contentBlocks.reduce<Integration['contentByTitle']>(
-          (memo, block) => {
-            const lowerCasedTitle = block.title.toLowerCase();
+  return useQuery<GeneratedIntegration, ErrorState, Integration>({
+    queryKey: ['integration', integrationId],
+    queryFn: () => integrationApi.getIntegration({ integrationId }),
+    select: ({ id, installed, name, description, contentBlocks }) => {
+      const contentByTitle = contentBlocks.reduce<Integration['contentByTitle']>(
+        (memo, block) => {
+          const lowerCasedTitle = block.title.toLowerCase();
 
-            return {
-              ...memo,
-              [lowerCasedTitle]: {
-                ...memo[lowerCasedTitle],
-                content: block.content,
-                codeSnippets: block.codeSnippets,
-              },
-            };
-          },
-          {}
-        );
+          return {
+            ...memo,
+            [lowerCasedTitle]: {
+              ...memo[lowerCasedTitle],
+              content: block.content,
+              codeSnippets: block.codeSnippets,
+            },
+          };
+        },
+        {}
+      );
 
-        return { id: id as DatasourceName, name, description, installed, contentByTitle };
-      },
-    }
-  );
+      return { id: id as DatasourceName, name, description, installed, contentByTitle };
+    },
+  });
 }

--- a/odd-platform-ui/src/lib/hooks/api/terms.ts
+++ b/odd-platform-ui/src/lib/hooks/api/terms.ts
@@ -11,9 +11,10 @@ export function useGetTermByNamespaceAndName() {
 
   return async ({ namespaceName, termName }: TermApiGetTermByNamespaceAndNameRequest) => {
     try {
-      return await queryClient.fetchQuery(['terms', namespaceName, termName], () =>
-        termApi.getTermByNamespaceAndName({ namespaceName, termName })
-      );
+      return await queryClient.fetchQuery({
+        queryKey: ['terms', namespaceName, termName],
+        queryFn: () => termApi.getTermByNamespaceAndName({ namespaceName, termName }),
+      });
     } catch (error) {
       return error as AppError;
     }

--- a/odd-platform-ui/src/lib/interfaces/shared.ts
+++ b/odd-platform-ui/src/lib/interfaces/shared.ts
@@ -11,7 +11,7 @@ export interface DataSetVersionDiff extends GeneratedDataSetVersionDiff {
 
 export interface InfiniteQueryPageInfo {
   total: number;
-  nextPage: number;
+  nextPage?: number;
 }
 
 export type Lang = keyof typeof LANGUAGES_MAP;

--- a/odd-platform-ui/src/redux/lib/handleResponseThunk.ts
+++ b/odd-platform-ui/src/redux/lib/handleResponseThunk.ts
@@ -26,7 +26,7 @@ export const handleResponseAsyncThunk = <Returned, ThunkArg = void>(
     try {
       const response = (await thunk(arg, thunkAPI)) as Returned;
 
-      if (options && options.setSuccessOptions) {
+      if (options?.setSuccessOptions) {
         const { id, message } = options.setSuccessOptions(arg);
         showSuccessToast({ id, message });
       }


### PR DESCRIPTION
_Why do we need this?_
We are going to reduce redux usage across app especially in places where common storage doesn't make sense and produces a lot of boilerplate code. For that purpose we have to keep libraries that will take a place in data fetching and management on FE.