### PR TITLE
1608 - added support of AWS Parameters Store

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,8 @@
 [versions]
 spring-webflux = '6.0.9'
+spring-aws-param-store = '2.2.6.RELEASE'
+spring-starter-cloud = '3.1.0'
+spring-starter-bootstrap = '3.1.0'
 reactor-extra = '3.5.1'
 micrometer-registry-prometheus = '1.9.0'
 ingestion-contract-server = '0.1.38'
@@ -47,6 +50,9 @@ spring-freemarker = '3.1.5'
 
 [libraries]
 spring-starter-webflux = { module = 'org.springframework.boot:spring-boot-starter-webflux' }
+spring-starter-cloud = { module = 'org.springframework.cloud:spring-cloud-starter', version.ref = 'spring-starter-cloud' }
+spring-starter-bootstrap = { module = 'org.springframework.cloud:spring-cloud-starter-bootstrap', version.ref = 'spring-starter-bootstrap' }
+spring-aws-param-store = { module = 'org.springframework.cloud:spring-cloud-starter-aws-parameter-store-config', version.ref = 'spring-aws-param-store'}
 spring-webflux = { module = 'org.springframework:spring-webflux', version.ref = 'spring-webflux' }
 spring-jooq = { module = 'org.springframework.boot:spring-boot-starter-jooq' }
 spring-actuator = { module = 'org.springframework.boot:spring-boot-starter-actuator' }
@@ -120,6 +126,9 @@ okhttp = { module = 'com.squareup.okhttp3:okhttp', version.ref = 'okhttp' }
 [bundles]
 spring = [
     'spring-starter-webflux',
+    'spring-starter-cloud',
+    'spring-starter-bootstrap',
+    'spring-aws-param-store',
     'spring-jooq',
     'spring-actuator',
     'spring-security',

--- a/odd-platform-api/src/main/resources/bootstrap.yml
+++ b/odd-platform-api/src/main/resources/bootstrap.yml
@@ -1,0 +1,8 @@
+aws:
+  paramstore:
+    prefix: /odd
+    enabled: false
+    profileSeparator: "_"
+    name: platform_config
+  secretsmanager:
+    enabled: false


### PR DESCRIPTION
By default, AWS Parameters Store is disabled. 
In case, user want to enable it, need to specify:

- AWS_PARAMSTORE_ENABLED=true (for default values)
- AWS_SECRETSMANAGER_ENABLED=true (for Secured values)

Note : this naming is [hardcoded](https://docs.spring.io/spring-cloud-aws/docs/2.2.3.RELEASE/reference/html/appendix.html)
In case, you want to enable this on your local env, you should also specify:
- AWS_ACCESS_KEY_ID
- AWS_REGION
- AWS_SECRET_KEY

([How to setup this variables for local env](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/signup-create-iam-user.html))

By default, 
aws.paramstore.prefix = /odd
aws.paramstore.name = platform_config
In result, platform will get variables which have naming like: /odd/platform_config/[variable.name]

IMPORTANT
As name separator for variable, you should use `'.'`, not `'_'`.  
This rule only for variables naming. Name of profile can be separated by `'_'.` 
Example:
In applciation.yml we have following property

```
auth:
  type: DISABLED
```

1)In parameters store we have this : /odd/platform_config/auth.type=OAUTH2. Result: applciation.yml will be overridden and we will have  OAUTH2
2)In parameters store we have this : /odd/platform_config/auth_type=OAUTH2. Result: applciation.yml will NOT be overridden and we will have DISABLED
Screenshots:
variables in paramstore
<img width="1538" alt="image" src="https://github.com/opendatadiscovery/odd-platform/assets/45620393/584828e8-e80e-4878-994c-bb6dc98e37b2">
Their values in application

<img width="500" alt="image" src="https://github.com/opendatadiscovery/odd-platform/assets/45620393/9a9fb8ed-479d-45ac-8e7a-1490a57f057b">
