### PR TITLE
hotfix: fetch policy schema

### DIFF
--- a/odd-platform-ui/src/redux/thunks/policy.thunks.ts
+++ b/odd-platform-ui/src/redux/thunks/policy.thunks.ts
@@ -84,9 +84,8 @@ export const fetchPolicyDetails = handleResponseAsyncThunk<
 export const fetchPolicySchema = handleResponseAsyncThunk<Record<string, unknown>, void>(
   actions.fetchPolicySchemaActType,
   async () => {
-    const schema = await policyApi.getPolicySchema();
     try {
-      return JSON.parse(schema);
+      return (await policyApi.getPolicySchema()) as unknown as Record<string, unknown>;
     } catch (e) {
       throw new Error(e?.toString());
     }


### PR DESCRIPTION
this is openapi codegen weird behaviour. According openapi spec it must returns string but in reality it returns json parsed object.