### PR TITLE
Hide "Sync your account with existing owner" with no authentication method configured

### DIFF
--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/controller/AppInfoController.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/controller/AppInfoController.java
@@ -1,8 +1,8 @@
 package org.opendatadiscovery.oddplatform.controller;
 
-import lombok.RequiredArgsConstructor;
 import org.opendatadiscovery.oddplatform.api.contract.api.AppInfoApi;
 import org.opendatadiscovery.oddplatform.api.contract.model.AppInfo;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,13 +10,21 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 @RestController
-@RequiredArgsConstructor
 public class AppInfoController implements AppInfoApi {
     private final BuildProperties buildProperties;
+    private final String authType;
+
+    public AppInfoController(final BuildProperties buildProperties,
+                             @Value("${auth.type}") final String authType) {
+        this.buildProperties = buildProperties;
+        this.authType = authType;
+    }
 
     @Override
     public Mono<ResponseEntity<AppInfo>> getAppInfo(final ServerWebExchange exchange) {
-        return Mono.just(new AppInfo().projectVersion(buildProperties.getVersion()))
+        return Mono.just(new AppInfo()
+                .projectVersion(buildProperties.getVersion())
+                .authType(authType))
             .map(ResponseEntity::ok);
     }
 }

--- a/odd-platform-specification/components.yaml
+++ b/odd-platform-specification/components.yaml
@@ -2458,6 +2458,8 @@ components:
       properties:
         projectVersion:
           type: string
+        authType:
+          type: string
 
     LinkedTerm:
       type: object

--- a/odd-platform-ui/src/components/Overview/Overview.tsx
+++ b/odd-platform-ui/src/components/Overview/Overview.tsx
@@ -5,6 +5,7 @@ import { MainSearch, SkeletonWrapper } from 'components/shared/elements';
 import { WithPermissionsProvider } from 'components/shared/contexts';
 import { Permission } from 'generated-sources';
 import { useAppSelector } from 'redux/lib/hooks';
+import { useAppInfo } from 'lib/hooks/api';
 import Domains from 'components/Overview/Domains/Domains';
 import { useGetPopularTags } from 'lib/hooks/api/tags';
 import DataEntitiesUsageInfo from './DataEntitiesUsageInfo/DataEntitiesUsageInfo';
@@ -20,6 +21,10 @@ const Overview: React.FC = () => {
     page: 1,
     size: 30,
   });
+  const { data: appInfo } = useAppInfo();
+  const isShowOwnerAssociation = Boolean(
+    appInfo?.authType && appInfo.authType !== 'DISABLED'
+  );
 
   const isLoading = React.useMemo(
     () => isIdentityFetching || isTagsFetching,
@@ -41,17 +46,17 @@ const Overview: React.FC = () => {
       <Grid container justifyContent='center' sx={{ pt: 4, pb: 5 }}>
         <MainSearch mainSearch />
       </Grid>
-      <S.TagsContainer container>
-        {tags ? <TopTagsList tags={tags} /> : null}
-      </S.TagsContainer>
+      <S.TagsContainer container>{tags && <TopTagsList tags={tags} />}</S.TagsContainer>
       <Domains />
       <DataEntitiesUsageInfo />
       <Directory />
-      <WithPermissionsProvider
-        allowedPermissions={[Permission.DIRECT_OWNER_SYNC]}
-        resourcePermissions={[]}
-        Component={OwnerAssociation}
-      />
+      {isShowOwnerAssociation && (
+        <WithPermissionsProvider
+          allowedPermissions={[Permission.DIRECT_OWNER_SYNC]}
+          resourcePermissions={[]}
+          Component={OwnerAssociation}
+        />
+      )}
     </S.Container>
   );
 };

--- a/odd-platform-ui/src/components/shared/elements/AppToolbar/AppInfoMenu/AppInfoMenu.tsx
+++ b/odd-platform-ui/src/components/shared/elements/AppToolbar/AppInfoMenu/AppInfoMenu.tsx
@@ -14,7 +14,7 @@ import * as S from 'components/shared/elements/AppToolbar/AppInfoMenu/AppInfoMen
 import Button from 'components/shared/elements/Button/Button';
 
 const AppInfoMenu: React.FC = () => {
-  const { data: version } = useAppInfo();
+  const { data: appInfo } = useAppInfo();
   const { data: links } = useAppLinks();
 
   const gitbookLink = 'https://docs.opendatadiscovery.org/';
@@ -35,7 +35,7 @@ const AppInfoMenu: React.FC = () => {
   };
 
   const projectVersion = React.useMemo(() => {
-    if (!version) return null;
+    if (!appInfo?.projectVersion) return null;
 
     return (
       <Link to={githubLink} target='_blank'>
@@ -44,13 +44,13 @@ const AppInfoMenu: React.FC = () => {
             <GitHubIcon />
           </S.Icon>
           <Grid container flexDirection='column'>
-            <Typography variant='h4'>{version}</Typography>
+            <Typography variant='h4'>{appInfo.projectVersion}</Typography>
             <Typography variant='subtitle1'>ODD Platform version</Typography>
           </Grid>
         </S.MenuItem>
       </Link>
     );
-  }, [version]);
+  }, [appInfo?.projectVersion]);
 
   const projectLinks = React.useMemo(() => {
     if (!links || links.length === 0) return null;

--- a/odd-platform-ui/src/lib/hooks/api/appInfo.ts
+++ b/odd-platform-ui/src/lib/hooks/api/appInfo.ts
@@ -5,7 +5,6 @@ export function useAppInfo() {
   return useQuery({
     queryKey: ['appInfo'],
     queryFn: () => appInfoApi.getAppInfo(),
-    select: data => data.projectVersion,
   });
 }
 


### PR DESCRIPTION
This pull request fixes the issue where a user receives a 500 Internal Server Error for owner association requests when trying to "Sync your account with existing owner" with no authentication method configured. The functionality is now disabled if no authentication method is provided in the config.

authType: DISABLED

![image](https://github.com/opendatadiscovery/odd-platform/assets/106543964/b5b397b6-6d20-45ce-8eef-491d557a7eae)

authType: other options

![image](https://github.com/opendatadiscovery/odd-platform/assets/106543964/dcfc7334-9ac7-4228-9949-4990042acb9b)


Fixes #1380