### PR TITLE
1657 - activity "User" filter should accept usernames instead of owner_ids

### DIFF
--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/controller/ActivityController.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/controller/ActivityController.java
@@ -8,6 +8,7 @@ import org.opendatadiscovery.oddplatform.api.contract.model.Activity;
 import org.opendatadiscovery.oddplatform.api.contract.model.ActivityCountInfo;
 import org.opendatadiscovery.oddplatform.api.contract.model.ActivityEventType;
 import org.opendatadiscovery.oddplatform.api.contract.model.ActivityType;
+import org.opendatadiscovery.oddplatform.api.contract.model.ActivityUserList;
 import org.opendatadiscovery.oddplatform.service.activity.ActivityService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,7 +29,7 @@ public class ActivityController implements ActivityApi {
                                                             final Long namespaceId,
                                                             final List<Long> tagIds,
                                                             final List<Long> ownerIds,
-                                                            final List<Long> userIds,
+                                                            final List<String> usernames,
                                                             final ActivityType type,
                                                             final ActivityEventType eventType,
                                                             final Long lasEventId,
@@ -36,7 +37,7 @@ public class ActivityController implements ActivityApi {
                                                             final ServerWebExchange exchange) {
         return Mono.just(
                 activityService.getActivityList(beginDate, endDate, size, datasourceId, namespaceId, tagIds, ownerIds,
-                    userIds, type, eventType, lasEventId, lastEventDateTime))
+                    usernames, type, eventType, lasEventId, lastEventDateTime))
             .map(ResponseEntity::ok);
     }
 
@@ -47,11 +48,20 @@ public class ActivityController implements ActivityApi {
                                                                      final Long namespaceId,
                                                                      final List<Long> tagIds,
                                                                      final List<Long> ownerIds,
-                                                                     final List<Long> userIds,
+                                                                     final List<String> usernames,
                                                                      final ActivityEventType eventType,
                                                                      final ServerWebExchange exchange) {
         return activityService.getActivityCounts(beginDate, endDate, datasourceId, namespaceId,
-                tagIds, ownerIds, userIds, eventType)
+                tagIds, ownerIds, usernames, eventType)
+            .map(ResponseEntity::ok);
+    }
+
+    @Override
+    public Mono<ResponseEntity<ActivityUserList>> getUsersList(final Integer page,
+                                                               final Integer size,
+                                                               final String query,
+                                                               final ServerWebExchange exchange) {
+        return activityService.getUsersList(page, size, query)
             .map(ResponseEntity::ok);
     }
 }

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/controller/DataEntityController.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/controller/DataEntityController.java
@@ -353,13 +353,13 @@ public class DataEntityController implements DataEntityApi {
                                                                       final OffsetDateTime beginDate,
                                                                       final OffsetDateTime endDate,
                                                                       final Integer size,
-                                                                      final List<Long> userIds,
+                                                                      final List<String> usernames,
                                                                       final ActivityEventType eventType,
                                                                       final Long lastEventId,
                                                                       final OffsetDateTime lastEventDateTime,
                                                                       final ServerWebExchange exchange) {
         return Mono.just(
-            activityService.getDataEntityActivityList(beginDate, endDate, size, dataEntityId, userIds, eventType,
+            activityService.getDataEntityActivityList(beginDate, endDate, size, dataEntityId, usernames, eventType,
                 lastEventId, lastEventDateTime)
         ).map(ResponseEntity::ok);
     }

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/dto/activity/UsernameDto.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/dto/activity/UsernameDto.java
@@ -1,0 +1,6 @@
+package org.opendatadiscovery.oddplatform.dto.activity;
+
+import org.opendatadiscovery.oddplatform.model.tables.pojos.OwnerPojo;
+
+public record UsernameDto(String username, OwnerPojo ownerPojo) {
+}

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/mapper/ActivityMapper.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/mapper/ActivityMapper.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jooq.JSONB;
 import org.mapstruct.Mapper;
@@ -12,6 +13,8 @@ import org.mapstruct.Named;
 import org.mapstruct.NullValueCheckStrategy;
 import org.opendatadiscovery.oddplatform.api.contract.model.Activity;
 import org.opendatadiscovery.oddplatform.api.contract.model.ActivityState;
+import org.opendatadiscovery.oddplatform.api.contract.model.ActivityUser;
+import org.opendatadiscovery.oddplatform.api.contract.model.ActivityUserList;
 import org.opendatadiscovery.oddplatform.api.contract.model.AlertHaltConfigActivityState;
 import org.opendatadiscovery.oddplatform.api.contract.model.AlertReceivedActivityState;
 import org.opendatadiscovery.oddplatform.api.contract.model.AlertStatusUpdatedActivityState;
@@ -31,6 +34,7 @@ import org.opendatadiscovery.oddplatform.api.contract.model.DatasetFieldTermsAct
 import org.opendatadiscovery.oddplatform.api.contract.model.DatasetFieldValuesActivityState;
 import org.opendatadiscovery.oddplatform.api.contract.model.DescriptionActivityState;
 import org.opendatadiscovery.oddplatform.api.contract.model.OwnershipActivityState;
+import org.opendatadiscovery.oddplatform.api.contract.model.PageInfo;
 import org.opendatadiscovery.oddplatform.api.contract.model.TagActivityState;
 import org.opendatadiscovery.oddplatform.api.contract.model.TermActivityState;
 import org.opendatadiscovery.oddplatform.dto.AssociatedOwnerDto;
@@ -53,10 +57,12 @@ import org.opendatadiscovery.oddplatform.dto.activity.DescriptionActivityStateDt
 import org.opendatadiscovery.oddplatform.dto.activity.OwnershipActivityStateDto;
 import org.opendatadiscovery.oddplatform.dto.activity.TagActivityStateDto;
 import org.opendatadiscovery.oddplatform.dto.activity.TermActivityStateDto;
+import org.opendatadiscovery.oddplatform.dto.activity.UsernameDto;
 import org.opendatadiscovery.oddplatform.model.tables.pojos.ActivityPojo;
 import org.opendatadiscovery.oddplatform.model.tables.pojos.DataEntityPojo;
 import org.opendatadiscovery.oddplatform.service.ingestion.util.DateTimeUtil;
 import org.opendatadiscovery.oddplatform.utils.JSONSerDeUtils;
+import org.opendatadiscovery.oddplatform.utils.Page;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(config = MapperConfig.class, uses = {DateTimeMapper.class})
@@ -309,4 +315,17 @@ public abstract class ActivityMapper {
         return associatedOwnerMapper.mapAssociatedOwner(
             new AssociatedOwnerDto(activityDto.activity().getCreatedBy(), activityDto.user(), null));
     }
+
+    public ActivityUserList mapToActivityUserList(final Page<UsernameDto> usernameDtos) {
+        return new ActivityUserList()
+            .items(mapActivityUsers(usernameDtos.getData()))
+            .pageInfo(new PageInfo().total(usernameDtos.getTotal()));
+    }
+
+    private List<ActivityUser> mapActivityUsers(final List<UsernameDto> dtos) {
+        return dtos.stream().map(this::mapToActivityUser).collect(Collectors.toList());
+    }
+
+    @Mapping(source = "ownerPojo.id", target = "ownerId")
+    abstract ActivityUser mapToActivityUser(final UsernameDto dto);
 }

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveActivityRepository.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveActivityRepository.java
@@ -4,7 +4,9 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.opendatadiscovery.oddplatform.dto.activity.ActivityDto;
 import org.opendatadiscovery.oddplatform.dto.activity.ActivityEventTypeDto;
+import org.opendatadiscovery.oddplatform.dto.activity.UsernameDto;
 import org.opendatadiscovery.oddplatform.model.tables.pojos.ActivityPojo;
+import org.opendatadiscovery.oddplatform.utils.Page;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -20,7 +22,7 @@ public interface ReactiveActivityRepository {
                                         final Long namespaceId,
                                         final List<Long> tagIds,
                                         final List<Long> ownerIds,
-                                        final List<Long> userIds,
+                                        final List<String> usernames,
                                         final ActivityEventTypeDto eventType,
                                         final Long lastEventId,
                                         final OffsetDateTime lastEventDateTime);
@@ -31,7 +33,7 @@ public interface ReactiveActivityRepository {
                                        final Long datasourceId,
                                        final Long namespaceId,
                                        final List<Long> tagIds,
-                                       final List<Long> userIds,
+                                       final List<String> usernames,
                                        final ActivityEventTypeDto eventType,
                                        final Long currentOwnerId,
                                        final Long lastEventId,
@@ -43,7 +45,7 @@ public interface ReactiveActivityRepository {
                                               final Long datasourceId,
                                               final Long namespaceId,
                                               final List<Long> tagIds,
-                                              final List<Long> userIds,
+                                              final List<String> usernames,
                                               final ActivityEventTypeDto eventType,
                                               final List<String> oddrns,
                                               final Long lastEventId,
@@ -53,7 +55,7 @@ public interface ReactiveActivityRepository {
                                                final OffsetDateTime endDate,
                                                final Integer size,
                                                final Long dataEntityId,
-                                               final List<Long> userIds,
+                                               final List<String> usernames,
                                                final ActivityEventTypeDto eventType,
                                                final Long lastEventId,
                                                final OffsetDateTime lastEventDateTime);
@@ -64,7 +66,7 @@ public interface ReactiveActivityRepository {
                                        final Long namespaceId,
                                        final List<Long> tagIds,
                                        final List<Long> ownerIds,
-                                       final List<Long> userIds,
+                                       final List<String> usernames,
                                        final ActivityEventTypeDto eventType);
 
     Mono<Long> getMyObjectsActivitiesCount(final OffsetDateTime beginDate,
@@ -72,7 +74,7 @@ public interface ReactiveActivityRepository {
                                            final Long datasourceId,
                                            final Long namespaceId,
                                            final List<Long> tagIds,
-                                           final List<Long> userIds,
+                                           final List<String> usernames,
                                            final ActivityEventTypeDto eventType,
                                            final Long currentOwnerId);
 
@@ -81,7 +83,9 @@ public interface ReactiveActivityRepository {
                                            final Long datasourceId,
                                            final Long namespaceId,
                                            final List<Long> tagIds,
-                                           final List<Long> userIds,
+                                           final List<String> usernames,
                                            final ActivityEventTypeDto eventType,
                                            final List<String> oddrns);
+
+    Mono<Page<UsernameDto>> getUsersList(final Integer page, final Integer size, final String query);
 }

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/service/activity/ActivityService.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/service/activity/ActivityService.java
@@ -7,6 +7,7 @@ import org.opendatadiscovery.oddplatform.api.contract.model.Activity;
 import org.opendatadiscovery.oddplatform.api.contract.model.ActivityCountInfo;
 import org.opendatadiscovery.oddplatform.api.contract.model.ActivityEventType;
 import org.opendatadiscovery.oddplatform.api.contract.model.ActivityType;
+import org.opendatadiscovery.oddplatform.api.contract.model.ActivityUserList;
 import org.opendatadiscovery.oddplatform.dto.activity.ActivityContextInfo;
 import org.opendatadiscovery.oddplatform.dto.activity.ActivityCreateEvent;
 import org.opendatadiscovery.oddplatform.dto.activity.ActivityEventTypeDto;
@@ -36,7 +37,7 @@ public interface ActivityService {
                                    final Long namespaceId,
                                    final List<Long> tagIds,
                                    final List<Long> ownerIds,
-                                   final List<Long> userIds,
+                                   final List<String> usernames,
                                    final ActivityType type,
                                    final ActivityEventType eventType,
                                    final Long lastEventId,
@@ -46,7 +47,7 @@ public interface ActivityService {
                                              final OffsetDateTime endDate,
                                              final Integer size,
                                              final Long dataEntityId,
-                                             final List<Long> userIds,
+                                             final List<String> usernames,
                                              final ActivityEventType eventType,
                                              final Long lastEventId,
                                              final OffsetDateTime lastEventDateTime);
@@ -57,6 +58,8 @@ public interface ActivityService {
                                               final Long namespaceId,
                                               final List<Long> tagIds,
                                               final List<Long> ownerIds,
-                                              final List<Long> userIds,
+                                              final List<String> usernames,
                                               final ActivityEventType eventType);
+
+    Mono<ActivityUserList> getUsersList(final Integer page, final Integer size, final String query);
 }

--- a/odd-platform-specification/components.yaml
+++ b/odd-platform-specification/components.yaml
@@ -4159,6 +4159,30 @@ components:
         body:
           type: string
 
+    ActivityUserList:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ActivityUser'
+        page_info:
+          $ref: '#/components/schemas/PageInfo'
+      required:
+        - items
+        - page_info
+
+    ActivityUser:
+      type: object
+      properties:
+        owner_id:
+          type: integer
+          format: int64
+        username:
+          type: string
+      required:
+        - name
+
   parameters:
     PageParam:
       name: page

--- a/odd-platform-specification/openapi.yaml
+++ b/odd-platform-specification/openapi.yaml
@@ -1403,13 +1403,12 @@ paths:
           schema:
             type: string
             format: date-time
-        - name: user_ids
+        - name: usernames
           in: query
           schema:
             type: array
             items:
-              type: integer
-              format: int64
+              type: string
         - name: event_type
           in: query
           schema:
@@ -3121,13 +3120,12 @@ paths:
             items:
               type: integer
               format: int64
-        - name: user_ids
+        - name: usernames
           in: query
           schema:
             type: array
             items:
-              type: integer
-              format: int64
+              type: string
         - name: type
           in: query
           schema:
@@ -3156,6 +3154,27 @@ paths:
                 type: array
                 items:
                   $ref: './components.yaml/#/components/schemas/Activity'
+      tags:
+        - activity
+
+  /api/activity/users:
+    get:
+      summary: List of users
+      description: Gets the list of existing users
+      operationId: getUsersList
+      parameters:
+        - $ref: './components.yaml/#/components/parameters/SearchParam'
+        - $ref: './components.yaml/#/components/parameters/PageParam'
+        - $ref: './components.yaml/#/components/parameters/SizeParam'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: './components.yaml/#/components/schemas/ActivityUserList'
+        '500':
+          $ref: './components.yaml/#/components/responses/InternalError'
       tags:
         - activity
 
@@ -3201,13 +3220,12 @@ paths:
             items:
               type: integer
               format: int64
-        - name: user_ids
+        - name: usernames
           in: query
           schema:
             type: array
             items:
-              type: integer
-              format: int64
+              type: string
         - name: event_type
           in: query
           schema:


### PR DESCRIPTION
BE:
1) added new endpoint GET /api/activity/users - should be used to retrieve usernames, which present in activity table. 
2) Updated /api/activity/counts, /api/dataentities/{data_entity_id}/activity and /api/activity - now accepting array of String instead of owner_ids for users. 

FE:
1) need to update /api/activity/counts, /api/dataentities/{data_entity_id}/activity and /api/activity API's
2) make request GET /api/activity/users to retrieve usernames on DataEntity-> Activity and Activity Tabs
<img width="705" alt="image" src="https://github.com/opendatadiscovery/odd-platform/assets/45620393/f7115909-6acc-445c-9bbe-e8903a173a8b">
<img width="1054" alt="image" src="https://github.com/opendatadiscovery/odd-platform/assets/45620393/59a7a146-d407-4fab-8fcb-d2823e986f43">
