### PR TITLE
Editing the terms shouldn't throw alerts. 

### DIFF
--- a/odd-platform-ui/src/components/Terms/TermSearch/TermForm/TermsForm.tsx
+++ b/odd-platform-ui/src/components/Terms/TermSearch/TermForm/TermsForm.tsx
@@ -80,18 +80,23 @@ const TermsForm: FC<TermsFormDialogProps> = ({ btnCreateEl }) => {
   };
 
   const onSubmit = (data: TermFormData) => {
-    const duplicateTerm = existingTerms.find(
-      (existingTerm: TermDetails) =>
-        existingTerm.name === data.name &&
-        existingTerm.namespace.name === data.namespaceName
-    );
+    // Check if we're in create mode (no term.id present)
+    if (!term?.id) {
+      const duplicateTerm = existingTerms.find(
+        (existingTerm: TermDetails) =>
+          existingTerm.name === data.name &&
+          existingTerm.namespace.name === data.namespaceName
+      );
 
-    if (duplicateTerm) {
-      setError('A term with the same name already exists in this namespace.');
-      return;
+      if (duplicateTerm) {
+        setError('A term with the same name already exists in this namespace.');
+        return;
+      }
     }
 
     const parsedData = { ...data };
+
+    // Determine whether to create or update the term
     (term && term.id
       ? dispatch(updateTerm({ termId: term.id, termFormData: parsedData }))
       : dispatch(createTerm({ termFormData: parsedData }))


### PR DESCRIPTION
This is the MR [#1700 ](https://github.com/opendatadiscovery/odd-platform/issues/1700). So whenever we edit the terms, it does not throw errors. The Rest of the functionality is the same. Please review the code and let me know if there are any issues. I'm happy to resolve them. I'm attaching the screenshot for reference.


![tesm-v29](https://github.com/user-attachments/assets/26d0bd2c-9ab1-482a-966b-4acc85beaf6d)
