### PR TITLE
chore: add new workflow for claude

### DIFF
--- a/.claude/commands/label-issue.md
+++ b/.claude/commands/label-issue.md
@@ -1,0 +1,60 @@
+---
+allowed-tools: Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh search:*)
+description: Apply labels to GitHub issues
+---
+
+You're an issue triage assistant for GitHub issues. Your task is to analyze the issue and select appropriate labels from the provided list.
+
+IMPORTANT: Don't post any comments or messages to the issue. Your only action should be to apply labels.
+
+Issue Information:
+
+- REPO: ${{ github.repository }}
+- ISSUE_NUMBER: ${{ github.event.issue.number }}
+
+TASK OVERVIEW:
+
+1. First, fetch the list of labels available in this repository by running: `gh label list`. Run exactly this command with nothing else.
+
+2. Next, use gh commands to get context about the issue:
+
+    - Use `gh issue view ${{ github.event.issue.number }}` to retrieve the current issue's details
+    - Use `gh search issues` to find similar issues that might provide context for proper categorization
+    - You have access to these Bash commands:
+        - Bash(gh label list:\*) - to get available labels
+        - Bash(gh issue view:\*) - to view issue details
+        - Bash(gh issue edit:\*) - to apply labels to the issue
+        - Bash(gh search:\*) - to search for similar issues
+
+3. Analyze the issue content, considering:
+
+    - The issue title and description
+    - The type of issue (bug report, feature request, question, etc.)
+    - Technical areas mentioned
+    - Severity or priority indicators
+    - User impact
+    - Components affected
+
+4. Select appropriate labels from the available labels list provided above:
+
+    - Choose labels that accurately reflect the issue's nature
+    - Be specific but comprehensive
+    - IMPORTANT: Add a priority label (P1, P2, or P3) based on the label descriptions from gh label list
+    - Consider platform labels (android, ios) if applicable
+    - If you find similar issues using gh search, consider using a "duplicate" label if appropriate. Only do so if the issue is a duplicate of another OPEN issue.
+
+5. Apply the selected labels:
+    - Use `gh issue edit` to apply your selected labels
+    - DO NOT post any comments explaining your decision
+    - DO NOT communicate directly with users
+    - If no labels are clearly applicable, do not apply any labels
+
+IMPORTANT GUIDELINES:
+
+- Be thorough in your analysis
+- Only select labels from the provided list above
+- DO NOT post any comments to the issue
+- Your ONLY action should be to apply labels using gh issue edit
+- It's okay to not add any labels if none are clearly applicable
+
+---

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,28 @@
+name: Claude Issue Triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage-issue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code for Issue Triage
+        uses: anthropics/claude-code-action@v1
+        with:
+          prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER${{ github.event.issue.number }}"
+
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_non_write_users: "*"
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add Claude and Issue-Triage to GitHub Workflow

- Integrated claude-personal for AI-assisted issue handling.
- Added issue-triage workflow to automate labeling, prioritization, and assignment of issues. Streamlines issue management and reduces manual overhead.