### PR TITLE
fix: prevent crash when term has no namespace on term details page

### DIFF
--- a/odd-platform-ui/src/components/shared/elements/Autocomplete/TermsAutocomplete/TermsAutocomplete.tsx
+++ b/odd-platform-ui/src/components/shared/elements/Autocomplete/TermsAutocomplete/TermsAutocomplete.tsx
@@ -83,6 +83,7 @@ const TermsAutocomplete: React.FC<TermsAutocompleteProps> = ({
     value: FilterOption | string | null
   ) => {
     if (!value) return;
+    if (typeof value !== 'string' && !value.id) return;
     setSelectedTerm(value as TermRef);
     setSearchText(typeof value === 'string' ? value : value.name);
     field.onChange(typeof value === 'string' ? value : value.id);

--- a/odd-platform-ui/src/components/shared/elements/forms/AssignTermForm.tsx
+++ b/odd-platform-ui/src/components/shared/elements/forms/AssignTermForm.tsx
@@ -70,7 +70,7 @@ const AssignTermForm: FC<AssignTermFormProps> = ({
             <Typography variant='body2' color='texts.secondary' component='span'>
               {t('Namespace')}:
             </Typography>
-            {selectedTerm.namespace.name}
+            {selectedTerm.namespace?.name}
           </Grid>
           <Grid container flexDirection='column' sx={{ mt: 2 }}>
             <Typography variant='body2' color='texts.secondary' component='span'>


### PR DESCRIPTION
Fixes a TypeError crash that caused a blank screen when opening a term whose namespace is null/undefined.

## Changes

- `AssignTermForm.tsx`: use optional chaining `selectedTerm.namespace?.name` to safely handle null namespace
- `TermsAutocomplete.tsx`: add guard to skip the "no results" placeholder option (which has no `id`) before calling `setSelectedTerm`, preventing a nameless object from propagating

Closes #1694

Generated with [Claude Code](https://claude.ai/code)