### PR TITLE
fix: add ML_MODEL type support to resolve 500 error on ingestion

### DIFF
--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/dto/DataEntityClassDto.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/dto/DataEntityClassDto.java
@@ -31,6 +31,7 @@ import static org.opendatadiscovery.oddplatform.dto.DataEntityTypeDto.KAFKA_TOPI
 import static org.opendatadiscovery.oddplatform.dto.DataEntityTypeDto.LOOKUP_TABLE;
 import static org.opendatadiscovery.oddplatform.dto.DataEntityTypeDto.MICROSERVICE;
 import static org.opendatadiscovery.oddplatform.dto.DataEntityTypeDto.ML_EXPERIMENT;
+import static org.opendatadiscovery.oddplatform.dto.DataEntityTypeDto.ML_MODEL;
 import static org.opendatadiscovery.oddplatform.dto.DataEntityTypeDto.ML_MODEL_ARTIFACT;
 import static org.opendatadiscovery.oddplatform.dto.DataEntityTypeDto.ML_MODEL_INSTANCE;
 import static org.opendatadiscovery.oddplatform.dto.DataEntityTypeDto.ML_MODEL_TRAINING;
@@ -45,7 +46,7 @@ public enum DataEntityClassDto {
     DATA_TRANSFORMER_RUN(3, JOB_RUN),
     DATA_QUALITY_TEST(4, JOB),
     DATA_QUALITY_TEST_RUN(5, JOB_RUN),
-    DATA_CONSUMER(6, Set.of(ML_MODEL_ARTIFACT, DASHBOARD)),
+    DATA_CONSUMER(6, Set.of(ML_MODEL_ARTIFACT, ML_MODEL, DASHBOARD)),
     DATA_INPUT(7, API_CALL),
     DATA_ENTITY_GROUP(8, Set.of(ML_EXPERIMENT, DAG, DATABASE_SERVICE, API_SERVICE, KAFKA_SERVICE, DOMAIN)),
     DATA_RELATIONSHIP(9, Set.of(ENTITY_RELATIONSHIP, GRAPH_RELATIONSHIP));

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/dto/DataEntityTypeDto.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/dto/DataEntityTypeDto.java
@@ -35,7 +35,8 @@ public enum DataEntityTypeDto {
     VECTOR_STORE(23),
     LOOKUP_TABLE(24),
     ENTITY_RELATIONSHIP(25),
-    GRAPH_RELATIONSHIP(26);
+    GRAPH_RELATIONSHIP(26),
+    ML_MODEL(27);
 
     private static final Map<Integer, DataEntityTypeDto> MAP = Arrays
         .stream(DataEntityTypeDto.values())

--- a/odd-platform-specification/components.yaml
+++ b/odd-platform-specification/components.yaml
@@ -780,6 +780,7 @@ components:
             - ML_EXPERIMENT
             - ML_MODEL_TRAINING
             - ML_MODEL_INSTANCE
+            - ML_MODEL
             - DASHBOARD
             - ML_MODEL_ARTIFACT
             - VIEW

--- a/odd-platform-ui/src/lib/constants.ts
+++ b/odd-platform-ui/src/lib/constants.ts
@@ -102,6 +102,7 @@ export const DataEntityClassTypeLabelMap: Map<
     TypeNameEnum.ML_MODEL_ARTIFACT,
     { normal: 'ML model artifact', plural: 'ML model artifacts' },
   ],
+  [TypeNameEnum.ML_MODEL, { normal: 'ML model', plural: 'ML models' }],
   [TypeNameEnum.DASHBOARD, { normal: 'Dashboard', plural: 'Dashboards' }],
   [TypeNameEnum.VIEW, { normal: 'View', plural: 'Views' }],
   [TypeNameEnum.DAG, { normal: 'Dag', plural: 'Dags' }],


### PR DESCRIPTION
Fixes #1725

## Summary

- Added `ML_MODEL(27)` to `DataEntityTypeDto` enum
- Mapped `ML_MODEL` to `DATA_CONSUMER` in `DataEntityClassDto`, consistent with payloads using a `data_consumer` block
- Added `ML_MODEL` to `DataEntityType.name` enum in `components.yaml` so generated API contract includes it (prevents secondary 500 when reading back entities)
- Added `ML_MODEL` display label to frontend `constants.ts` (takes effect after `pnpm generate`)

Generated with [Claude Code](https://claude.ai/code)