### PR TITLE
fix: downgrade netty-bom from 4.1.129 to 4.1.128 to fix UI static ass…

### DIFF
--- a/odd-platform-api/build.gradle
+++ b/odd-platform-api/build.gradle
@@ -71,7 +71,7 @@ dependencies {
 dependencyManagement {
     imports {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:2024.0.1"
-        mavenBom "io.netty:netty-bom:4.1.129.Final"
+        mavenBom "io.netty:netty-bom:4.1.128.Final"
     }
     dependencies {
         dependency 'com.nimbusds:nimbus-jose-jwt:9.37.4'


### PR DESCRIPTION
Netty 4.1.129.Final introduces stricter URI validation as part of the CVE-2025-67735 (CRLF injection in HttpRequestEncoder) fix. While the CVE itself only affects client-side HttpRequestEncoder (rejecting \r, \n, and space in outgoing request URIs), the version bump causes incompatibility with the Reactor Netty version shipped with Spring Boot 3.4.10 (which was built and tested against Netty 4.1.127).

This incompatibility results in Reactor Netty rejecting valid incoming HTTP requests for static UI assets with:
  "IllegalArgumentException: The URI contain illegal characters"
  returning HTTP 400 with connection: close

Approximately half of the Vite-built JS chunks were affected, breaking the frontend application.

Netty 4.1.128.Final is the correct version to use because:
- It includes the CVE-2025-59419 fix (SMTP command injection)
- It does NOT have the Reactor Netty incompatibility from 4.1.129
- CVE-2025-67735 only affects HttpRequestEncoder (client-side), not server-side request handling, so it is not a risk for this application

Long-term fix: upgrade Spring Boot to 3.4.11+ or 3.5.x when available, which will ship with a Reactor Netty version compatible with Netty 4.1.129+. At that point, the netty-bom can be upgraded together with Spring Boot.
