### PR TITLE
test: regression pins for LSN-001 (attachment ephemeral) + LSN-002 (m…

### DIFF
--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/config/AttachmentStorageDefaultRegressionPinTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/config/AttachmentStorageDefaultRegressionPinTest.java
@@ -1,0 +1,48 @@
+package org.opendatadiscovery.oddplatform.config;
+
+import java.util.Properties;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Regression pin for LSN-001 (attachment-storage ephemeral default).
+ *
+ * <p>The default {@code attachment.storage} is {@code LOCAL}, writing to
+ * {@code /tmp/odd/attachments} — which is EPHEMERAL: a container restart silently
+ * wipes every uploaded attachment (the 2026-04 production data-loss incident).
+ * This test pins the documented default so any change to it must consciously
+ * revisit the data-loss caveat in the operator docs and in ADR-0012
+ * (attachment-storage backend selected at boot).
+ *
+ * <p>This is a deterministic gate, not a free-floating test:
+ *
+ * @enforces ADR-0012
+ * @regresses LSN-001
+ */
+class AttachmentStorageDefaultRegressionPinTest {
+
+    @Test
+    void attachmentStorageDefault_isLocalEphemeralTmpPath() {
+        final YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+        factory.setResources(new ClassPathResource("application.yml"));
+        final Properties props = factory.getObject();
+
+        Assertions.assertThat(props)
+            .as("main application.yml must load from the test classpath")
+            .isNotNull();
+
+        // LSN-001: the shipped default backend is LOCAL (ephemeral). If this
+        // flips, the ephemeral-data-loss caveat (docs + ADR-0012) must be
+        // re-confirmed — the test forces that decision rather than letting the
+        // default drift silently.
+        Assertions.assertThat(props.getProperty("attachment.storage"))
+            .as("default attachment.storage — LSN-001 ephemeral default")
+            .isEqualTo("LOCAL");
+
+        Assertions.assertThat(props.getProperty("attachment.local.path"))
+            .as("LOCAL path is the tmp dir wiped on container restart — LSN-001")
+            .isEqualTo("/tmp/odd/attachments");
+    }
+}

--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/config/MinioRegionUnsetRegressionPinTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/config/MinioRegionUnsetRegressionPinTest.java
@@ -1,0 +1,46 @@
+package org.opendatadiscovery.oddplatform.config;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression pin for LSN-002 (MinIO region unset).
+ *
+ * <p>{@link MinioConfig#minioClient()} builds the {@code MinioAsyncClient} with
+ * {@code .endpoint(url).credentials(...).build()} and NO {@code .region(...)},
+ * and the config exposes no region property — so a REMOTE attachment backend
+ * only works against AWS {@code us-east-1} (the 2026-04 incident where operators
+ * following our guide hit a region that silently failed).
+ *
+ * <p>This pins the ABSENCE of any region knob: the only configurable inputs are
+ * the endpoint URL and credentials. When region support is added (a {@code region}
+ * field / {@code attachment.remote.region} property), this test fails — forcing
+ * the LSN-002 caveat and the builder fix to be confronted together rather than
+ * one drifting from the other.
+ *
+ * <p>This is a deterministic gate, not a free-floating test:
+ *
+ * @regresses LSN-002
+ */
+class MinioRegionUnsetRegressionPinTest {
+
+    @Test
+    void minioConfig_exposesNoRegionKnob() {
+        final List<String> instanceFields = Arrays.stream(MinioConfig.class.getDeclaredFields())
+            .filter(f -> !Modifier.isStatic(f.getModifiers()))
+            .map(Field::getName)
+            .toList();
+
+        // LSN-002: endpoint + credentials are the only configurable inputs; there
+        // is deliberately (and dangerously) NO region. Adding one must break this
+        // pin so the region caveat cannot silently disappear or silently appear.
+        Assertions.assertThat(instanceFields)
+            .as("MinioConfig configurable inputs — LSN-002 pins the absence of a region knob")
+            .containsExactlyInAnyOrder("url", "accessKey", "secretKey")
+            .doesNotContain("region");
+    }
+}


### PR DESCRIPTION
…inio region)

Two pure-unit regression pins for the 2026-04 production incidents, authored as deterministic gates (each declares which decision/bug it protects):

- AttachmentStorageDefaultRegressionPinTest — pins default attachment.storage= LOCAL → /tmp/odd/attachments (ephemeral, wiped on container restart, LSN-001). A change to the default fails the test, forcing the data-loss caveat + ADR-0012 to be revisited.  (@enforces ADR-0012 / @regresses LSN-001)
- MinioRegionUnsetRegressionPinTest — pins that MinioConfig exposes no region knob (endpoint + credentials only) → REMOTE storage is us-east-1-only until a region is added (LSN-002). Adding region support fails the pin, forcing the caveat + the builder fix together.  (@regresses LSN-002)

Pure unit tests — no Spring context, no Docker. Run:
  ./gradlew :odd-platform-api:test --tests "*RegressionPin*"

**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**

**How to test**