### PR TITLE
fix(ui): ConfirmationDialog no longer swallows a rejected confirm (#1…

### DIFF
--- a/odd-platform-ui/src/components/shared/elements/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/odd-platform-ui/src/components/shared/elements/ConfirmationDialog/ConfirmationDialog.tsx
@@ -3,6 +3,7 @@ import { Grid, Typography } from '@mui/material';
 import DialogWrapper from 'components/shared/elements/DialogWrapper/DialogWrapper';
 import * as S from 'components/shared/elements/ConfirmationDialog/ConfirmationDialogStyles';
 import Button from 'components/shared/elements/Button/Button';
+import { getErrorResponse } from 'lib/errorHandling';
 
 interface ConfirmationDialogProps {
   actionBtn: JSX.Element;
@@ -22,15 +23,25 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
   additionalContent,
 }) => {
   const [isLoading, setIsLoading] = React.useState(false);
+  const [errorText, setErrorText] = React.useState<string>();
   const onClose = (handleClose: () => void, action?: () => Promise<unknown>) => () => {
     if (action) {
+      setErrorText(undefined);
       setIsLoading(true);
       action()
         .then(() => {
           setIsLoading(false);
           handleClose();
         })
-        .catch(() => {});
+        .catch(async (err: unknown) => {
+          // A rejected confirm (e.g. a TanStack `mutateAsync` rejecting on a non-2xx) must NOT be
+          // swallowed: clear the loading state so the dialog is no longer mouse-dead (the
+          // DialogWrapper sets pointerEvents:none while loading), and surface the reason inline —
+          // leaving the dialog open so the user can read it and retry or cancel.
+          const { message } = await getErrorResponse(err);
+          setIsLoading(false);
+          setErrorText(message);
+        });
     }
   };
 
@@ -61,7 +72,13 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
     </S.Actions>
   );
 
-  React.useEffect(() => () => setIsLoading(false), [setIsLoading]);
+  React.useEffect(
+    () => () => {
+      setIsLoading(false);
+      setErrorText(undefined);
+    },
+    [setIsLoading, setErrorText]
+  );
 
   return (
     <DialogWrapper
@@ -73,6 +90,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
       renderContent={formContent}
       renderActions={formActionButtons}
       isLoading={isLoading}
+      errorText={errorText}
       formSubmitHandler={onConfirm}
     />
   );

--- a/odd-platform-ui/src/components/shared/elements/ConfirmationDialog/__tests__/ConfirmationDialog.test.tsx
+++ b/odd-platform-ui/src/components/shared/elements/ConfirmationDialog/__tests__/ConfirmationDialog.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+import { describe, it, expect, vi } from 'vitest';
+import theme from 'theme/mui.theme';
+import { render, clickByText } from 'lib/tests/testHelpers';
+import ConfirmationDialog from 'components/shared/elements/ConfirmationDialog/ConfirmationDialog';
+
+/**
+ * #1766 / CTRIB-027 — the shared ConfirmationDialog must NOT swallow a rejected onConfirm.
+ *
+ * On main, `onClose`'s `.catch(() => {})` discarded the rejection: `isLoading` was never reset (the
+ * DialogWrapper sets pointer-events:none while loading → a mouse-dead, wedged modal) and no reason was
+ * shown. These tests inject the failing condition explicitly (a rejecting onConfirm) and assert the
+ * FIXED contract: clear loading, surface the error inline, keep the dialog open. RED on main, GREEN on fix.
+ */
+const TITLE = 'Are you sure you want to delete this?';
+const CONFIRM = 'Confirm delete';
+
+// The design-system Button is MUI-styled (reads theme.palette.button.*), so the component tree needs the
+// MUI ThemeProvider in addition to the styled-components one the shared render helper supplies.
+const setup = (onConfirm: () => Promise<unknown>) =>
+  render(
+    <MuiThemeProvider theme={theme}>
+      <ConfirmationDialog
+        actionTitle={TITLE}
+        actionName={CONFIRM}
+        actionText='It will be deleted permanently'
+        onConfirm={onConfirm}
+        actionBtn={<button type='button'>open-trigger</button>}
+      />
+    </MuiThemeProvider>
+  );
+
+const openThenConfirm = async () => {
+  await clickByText('open-trigger');
+  expect(screen.getByText(TITLE), 'the dialog opened').toBeInTheDocument();
+  await clickByText(CONFIRM);
+};
+
+describe('ConfirmationDialog — rejected confirm handling (#1766 / CTRIB-027)', () => {
+  it('REJECTED onConfirm → surfaces the error inline and KEEPS the dialog open (no swallow)', async () => {
+    const onConfirm = vi.fn().mockRejectedValue({
+      // a generated-client ResponseError shape: the real Response sits at .response
+      response: new Response(
+        JSON.stringify({ message: 'Cannot delete: still referenced' }),
+        {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        }
+      ),
+    });
+
+    setup(onConfirm);
+    await openThenConfirm();
+
+    // the reason is shown inline (swallowed by `.catch(() => {})` on main)
+    expect(
+      await screen.findByText('Cannot delete: still referenced')
+    ).toBeInTheDocument();
+    // the dialog stays OPEN so the user can read it and retry / cancel
+    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('REJECTED onConfirm with no server message → shows the generic fallback, dialog stays open', async () => {
+    const onConfirm = vi.fn().mockRejectedValue(new Error('network down'));
+
+    setup(onConfirm);
+    await openThenConfirm();
+
+    expect(await screen.findByText('An error occurred')).toBeInTheDocument();
+    expect(screen.getByText(TITLE)).toBeInTheDocument();
+  });
+
+  it('RESOLVED onConfirm → closes the dialog (success path unchanged)', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+
+    setup(onConfirm);
+    await openThenConfirm();
+
+    await waitFor(() => expect(screen.queryByText(TITLE)).not.toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
…766)

The shared ConfirmationDialog's onClose did `action().then(...).catch(() => {})` — a rejected confirm (a TanStack `mutateAsync` rejecting on a non-2xx: cascade-block USR004, RBAC 403, 500, network) was swallowed, so `isLoading` was never reset. The DialogWrapper sets `pointer-events:none` while loading, so the modal wedged open, spinning, and mouse-dead — recoverable only by reloading the page. This hit the ~10 `mutateAsync` delete surfaces (lookup-table, attachments, query-examples, owner associations).

The `.catch` now clears the loading state and surfaces the reason inline via DialogWrapper's existing `errorText` prop (message from the existing `getErrorResponse` unwrap), leaving the dialog open so the operator can read the error and retry or cancel. The success path is unchanged.

Scope: the mutateAsync stuck-spinner only. The redux-thunk silent-close arm (the dispatch resolves on failure) and the term-delete navigate-away are tracked separately; the ResponseError toast-unwrap already shipped in #1771.

Test: ConfirmationDialog.test.tsx (RTL) — a rejecting onConfirm surfaces the inline error and keeps the dialog open; a resolving onConfirm closes it. An integration test (odd-team IT-138) drives the running UI under a forced 500: RED on main, GREEN here.

Consumer-read: ConfirmationDialog.tsx, DialogWrapper.tsx, DialogWrapperStyles.ts, lib/errorHandling.tsx, generated-sources/runtime.ts, index.tsx, redux/lib/handleResponseThunk.ts, lib/hooks/api/masterData/lookupTables.ts, MasterData/LookupTables/LookupTablesListItem.tsx,
Management/DataSourcesList/DataSourceItem/DataSourceItem.tsx, redux/thunks/datasources.thunks.ts, Terms/TermDetails/TermDetails.tsx Sources: odd-platform working tree @ origin/main 298f2f4c; #1771 (errorHandling ResponseError unwrap); live reproduction 2026-06-22 (CTRIB-027), IT-138

**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**

**How to test**