### PR TITLE
contrib(CTRIB-028): #1754 Term Detail page hardening (defects 1,2,4,5…

### DIFF
--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/mapper/DatasetFieldListMapper.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/mapper/DatasetFieldListMapper.java
@@ -5,5 +5,5 @@ import org.opendatadiscovery.oddplatform.api.contract.model.DatasetFieldList;
 import org.opendatadiscovery.oddplatform.dto.DatasetFieldTermsDto;
 
 public interface DatasetFieldListMapper {
-    DatasetFieldList mapPojos(List<DatasetFieldTermsDto> item);
+    DatasetFieldList mapPojos(List<DatasetFieldTermsDto> item, long total, int page, int size);
 }

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/mapper/DatasetFieldListMapperImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/mapper/DatasetFieldListMapperImpl.java
@@ -18,10 +18,11 @@ public class DatasetFieldListMapperImpl implements DatasetFieldListMapper {
     private final OwnershipMapper ownershipMapper;
 
     @Override
-    public DatasetFieldList mapPojos(final List<DatasetFieldTermsDto> dataFieldsDto) {
+    public DatasetFieldList mapPojos(final List<DatasetFieldTermsDto> dataFieldsDto,
+                                     final long total, final int page, final int size) {
         final List<TermSearchDataSetField> entities = dataFieldsDto.stream().map(this::mapPojo).toList();
-        final PageInfo pageInfo = pageInfo(dataFieldsDto.size());
-        return new DatasetFieldList(entities, pageInfo);
+        final boolean hasNext = (long) page * size < total;
+        return new DatasetFieldList(entities, new PageInfo().total(total).hasNext(hasNext));
     }
 
     private TermSearchDataSetField mapPojo(final DatasetFieldTermsDto dto) {
@@ -42,9 +43,5 @@ public class DatasetFieldListMapperImpl implements DatasetFieldListMapper {
             .dataEntityName(dto.getDataEntityName())
             .ownership(ownershipMapper.mapDtos(dto.getOwnership()))
             .dataSource(dataSourceMapper.mapDto(new DataSourceDto(dto.getDataSource(), dto.getNamespace(), null)));
-    }
-
-    private PageInfo pageInfo(final long total) {
-        return new PageInfo(total, false);
     }
 }

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveDatasetFieldRepository.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveDatasetFieldRepository.java
@@ -20,4 +20,6 @@ public interface ReactiveDatasetFieldRepository extends ReactiveCRUDRepository<D
 
     Flux<DatasetFieldTermsDto> listByTerm(final long termId, final String query,
                                           final int page, final int size);
+
+    Mono<Long> countByTerm(final long termId, final String query);
 }

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveDatasetFieldRepositoryImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveDatasetFieldRepositoryImpl.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import static org.jooq.impl.DSL.countDistinct;
 import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.jsonArrayAgg;
 import static org.jooq.impl.DSL.name;
@@ -201,6 +202,24 @@ public class ReactiveDatasetFieldRepositoryImpl
 
         return jooqReactiveOperations.flux(jooqQuery)
             .map(datasetFieldTermsDtoMapper::mapRecordToDto);
+    }
+
+    @Override
+    public Mono<Long> countByTerm(final long termId, final String query) {
+        final List<Condition> conditions = new ArrayList<>();
+        conditions.add(DATASET_FIELD_TO_TERM.TERM_ID.eq(termId));
+        if (StringUtils.isNotBlank(query)) {
+            conditions.add(DATASET_FIELD.NAME.containsIgnoreCase(query));
+        }
+
+        final var countQuery = select(countDistinct(DATASET_FIELD.ID))
+            .from(DATASET_FIELD)
+            .join(DATASET_FIELD_TO_TERM).on(DATASET_FIELD_TO_TERM.DATASET_FIELD_ID.eq(DATASET_FIELD.ID))
+            .where(conditions);
+
+        return jooqReactiveOperations.mono(countQuery)
+            .map(Record1::value1)
+            .map(Integer::longValue);
     }
 
     @NotNull

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/service/DatasetFieldServiceImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/service/DatasetFieldServiceImpl.java
@@ -183,9 +183,10 @@ public class DatasetFieldServiceImpl implements DatasetFieldService {
     @Override
     public Mono<DatasetFieldList> listByTerm(final Long termId, final String query,
                                              final Integer page, final Integer size) {
-        return reactiveDatasetFieldRepository.listByTerm(termId, query, page, size)
-            .collectList()
-            .map(datasetFieldListMapper::mapPojos);
+        return Mono.zip(
+                reactiveDatasetFieldRepository.listByTerm(termId, query, page, size).collectList(),
+                reactiveDatasetFieldRepository.countByTerm(termId, query))
+            .map(tuple -> datasetFieldListMapper.mapPojos(tuple.getT1(), tuple.getT2(), page, size));
     }
 
     private Mono<Void> updateFieldsTags(final Map<String, DataSetFieldStat> statisticsDict,

--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/mapper/DatasetFieldListMapperImplTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/mapper/DatasetFieldListMapperImplTest.java
@@ -1,0 +1,51 @@
+package org.opendatadiscovery.oddplatform.mapper;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.opendatadiscovery.oddplatform.api.contract.model.DatasetFieldList;
+import org.opendatadiscovery.oddplatform.dto.DatasetFieldTermsDto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit coverage for #1754 Defect 4 (CTRIB-028): the term linked-columns page_info must report the REAL
+ * total + a correct hasNext, not the returned page size with hasNext hardcoded false. The boundary math
+ * is the new behaviour (pre-fix: new PageInfo(dataFieldsDto.size(), false)). The end-to-end RED→GREEN
+ * proof on the running system is integration IT-139.
+ */
+class DatasetFieldListMapperImplTest {
+    // mapPojo (per-row mapping) is not exercised by these page_info-math cases, so the row mappers are mocks.
+    private final DatasetFieldListMapper mapper =
+        new DatasetFieldListMapperImpl(mock(DataSourceMapper.class), mock(OwnershipMapper.class));
+
+    @Test
+    @DisplayName("page_info reports the real total + hasNext=true on an intermediate page")
+    void pageInfoReportsRealTotalAndHasNextOnIntermediatePage() {
+        // 60 linked columns, page 1 of size 50 -> there ARE more pages
+        final DatasetFieldList result = mapper.mapPojos(List.<DatasetFieldTermsDto>of(), 60L, 1, 50);
+
+        assertThat(result.getPageInfo().getTotal()).isEqualTo(60L);
+        assertThat(result.getPageInfo().getHasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("page_info has no next page on the last page")
+    void pageInfoHasNoNextOnLastPage() {
+        // 60 linked columns, page 2 of size 50 -> last page
+        final DatasetFieldList result = mapper.mapPojos(List.<DatasetFieldTermsDto>of(), 60L, 2, 50);
+
+        assertThat(result.getPageInfo().getTotal()).isEqualTo(60L);
+        assertThat(result.getPageInfo().getHasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("page_info has no next page when the total fits in one page")
+    void pageInfoHasNoNextWhenTotalFitsOnePage() {
+        final DatasetFieldList result = mapper.mapPojos(List.<DatasetFieldTermsDto>of(), 10L, 1, 50);
+
+        assertThat(result.getPageInfo().getTotal()).isEqualTo(10L);
+        assertThat(result.getPageInfo().getHasNext()).isFalse();
+    }
+}

--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/service/DatasetFieldServiceImplTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/service/DatasetFieldServiceImplTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opendatadiscovery.oddplatform.api.contract.model.DatasetFieldList;
 import org.opendatadiscovery.oddplatform.api.contract.model.InternalNameFormData;
+import org.opendatadiscovery.oddplatform.dto.DatasetFieldTermsDto;
 import org.opendatadiscovery.oddplatform.exception.NotFoundException;
 import org.opendatadiscovery.oddplatform.mapper.DatasetFieldApiMapper;
 import org.opendatadiscovery.oddplatform.mapper.DatasetFieldListMapper;
@@ -18,11 +20,15 @@ import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveSearchEntry
 import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveTagRepository;
 import org.opendatadiscovery.oddplatform.service.ingestion.DatasetVersionHashCalculator;
 import org.opendatadiscovery.oddplatform.service.term.TermService;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -72,5 +78,29 @@ class DatasetFieldServiceImplTest {
             .thenReturn(Mono.error(new AssertionError("updated search vectors despite the field not existing")));
         StepVerifier.create(service.updateInternalName(FIELD_ID, new InternalNameFormData()))
             .verifyError(NotFoundException.class);
+    }
+
+    /**
+     * #1754 Defect 4 (CTRIB-028): listByTerm zips the page of linked columns with the REAL total from
+     * countByTerm and maps them — so the page_info reports the honest total/hasNext (the mapper is given the
+     * count, page and size). The end-to-end honest-page_info proof on the running system is integration IT-139.
+     *
+     * @validates F-153
+     */
+    @Test
+    void listByTerm_zipsLinkedColumnsWithTheRealCount_andMapsThem() {
+        final long termId = 7L;
+        final int page = 1;
+        final int size = 50;
+        final DatasetFieldList expected = mock(DatasetFieldList.class);
+
+        when(reactiveDatasetFieldRepository.listByTerm(termId, null, page, size))
+            .thenReturn(Flux.<DatasetFieldTermsDto>empty());
+        when(reactiveDatasetFieldRepository.countByTerm(termId, null)).thenReturn(Mono.just(60L));
+        when(datasetFieldListMapper.mapPojos(anyList(), eq(60L), eq(page), eq(size))).thenReturn(expected);
+
+        StepVerifier.create(service.listByTerm(termId, null, page, size))
+            .expectNext(expected)
+            .verifyComplete();
     }
 }

--- a/odd-platform-ui/src/components/Terms/TermDetails/Overview/Overview.tsx
+++ b/odd-platform-ui/src/components/Terms/TermDetails/Overview/Overview.tsx
@@ -4,8 +4,12 @@ import { SkeletonWrapper } from 'components/shared/elements';
 import { Permission, PermissionResourceType } from 'generated-sources';
 import { WithPermissionsProvider } from 'components/shared/contexts';
 import { useTermsRouteParams } from 'routes';
-import { useGetTermByID } from 'lib/hooks';
-import { useResourcePermissions } from 'lib/hooks/api/permissions';
+import { useAppSelector } from 'redux/lib/hooks';
+import {
+  getResourcePermissions,
+  getTermDetails,
+  getTermDetailsFetchingStatuses,
+} from 'redux/selectors';
 import OverviewGeneral from './OverviewGeneral/OverviewGeneral';
 import OverviewSkeleton from './OverviewSkeleton/OverviewSkeleton';
 import OverviewTags from './OverviewTags/OverviewTags';
@@ -16,13 +20,15 @@ import TermDefinition from './TermDefinition/TermDefinition';
 const Overview: FC = () => {
   const { termId } = useTermsRouteParams();
 
-  const { data: termDetails, isLoading: isTermDetailsFetching } = useGetTermByID({
-    termId,
-  });
-  const { data: termPermissions } = useResourcePermissions({
-    resourceId: termId,
-    permissionResourceType: PermissionResourceType.TERM,
-  });
+  // Read the term details + permissions the shell (TermDetails.tsx) already loaded into redux,
+  // instead of issuing a second GET /api/terms/{id} (+ permissions) of the 13-JOIN hot path.
+  const termDetails = useAppSelector(getTermDetails(termId));
+  const termPermissions = useAppSelector(
+    getResourcePermissions(PermissionResourceType.TERM, termId)
+  );
+  const { isLoading: isTermDetailsFetching } = useAppSelector(
+    getTermDetailsFetchingStatuses
+  );
 
   const linkedTerms = useMemo(() => termDetails?.terms || [], [termDetails]);
   const termsRef = useMemo(
@@ -32,7 +38,7 @@ const Overview: FC = () => {
 
   return (
     <>
-      {termDetails && !isTermDetailsFetching && (
+      {termDetails.id && !isTermDetailsFetching && (
         <Grid container spacing={2} sx={{ mt: 0 }}>
           <Grid item xs={8}>
             <S.DefinitionContainer elevation={9}>

--- a/odd-platform-ui/src/components/Terms/TermDetails/TermDetailsTabs/TermDetailsTabs.tsx
+++ b/odd-platform-ui/src/components/Terms/TermDetails/TermDetailsTabs/TermDetailsTabs.tsx
@@ -21,19 +21,16 @@ const TermDetailsTabs: React.FC = () => {
         name: t('Linked entities'),
         link: termDetailsPath(termId, 'linked-entities'),
         hint: termDetails?.entitiesUsingCount,
-        hidden: !termDetails?.entitiesUsingCount,
       },
       {
         name: t('Linked columns'),
         link: termDetailsPath(termId, 'linked-columns'),
         hint: termDetails?.columnsUsingCount,
-        hidden: !termDetails?.columnsUsingCount,
       },
       {
         name: t('Linked terms'),
         link: termDetailsPath(termId, 'linked-terms'),
         hint: termDetails?.linkedTermsUsingCount,
-        hidden: !termDetails?.linkedTermsUsingCount,
       },
       {
         name: t('Query examples'),

--- a/odd-platform-ui/src/components/Terms/TermDetails/TermLinkedColumnsList/LinkedColumnsList.tsx
+++ b/odd-platform-ui/src/components/Terms/TermDetails/TermLinkedColumnsList/LinkedColumnsList.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useEffect, useState } from 'react';
+import React, { type FC, useState } from 'react';
 import { Grid, Typography } from '@mui/material';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { useTranslation } from 'react-i18next';
@@ -18,17 +18,19 @@ const size = 50;
 const LinkedColumnsList: FC = () => {
   const { t } = useTranslation();
   const { termId } = useTermsRouteParams();
-  const [query, setQuery] = useState('');
-  const {
-    data: { items, pageInfo },
-    isFetching,
-    isFetched,
-    refetch: search,
-  } = useGetTermLinkedColumns({ termId, page: 1, size, query });
 
-  useEffect(() => {
-    search();
-  }, []);
+  // query drives the input (immediate); submittedQuery feeds the request (on demand — Enter / icon
+  // click), preserving this tab's existing on-demand search while adding pagination past the size cap.
+  const [query, setQuery] = useState('');
+  const [submittedQuery, setSubmittedQuery] = useState('');
+
+  const { data, isFetching, isFetched, fetchNextPage, hasNextPage } =
+    useGetTermLinkedColumns({ termId, size, query: submittedQuery });
+
+  const items = data?.pages.flatMap(page => page.items) ?? [];
+  const total = data?.pages[0]?.pageInfo.total;
+
+  const search = () => setSubmittedQuery(query);
 
   const handleKeyDownSearch = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter') search();
@@ -68,14 +70,14 @@ const LinkedColumnsList: FC = () => {
       </TermLinkedColumnsResultsTableHeader>
       {isFetching && <LinkedColumnsListSkeleton />}
       <TermLinkedColumnsListContainer
-        $isListEmpty={!pageInfo.total && isFetched}
+        $isListEmpty={!total && isFetched}
         id='term-linked-columns-list'
       >
         {items.length > 0 && (
           <InfiniteScroll
             dataLength={items.length}
-            next={() => {}}
-            hasMore={pageInfo.hasNext}
+            next={fetchNextPage}
+            hasMore={hasNextPage ?? false}
             loader={isFetching && <LinkedColumnsListSkeleton />}
             scrollThreshold='200px'
             scrollableTarget='term-linked-columns-list'
@@ -89,7 +91,7 @@ const LinkedColumnsList: FC = () => {
       <EmptyContentPlaceholder
         text={t('No linked columns')}
         isContentLoaded={!isFetching && isFetched}
-        isContentEmpty={!pageInfo.total}
+        isContentEmpty={!total}
       />
     </Grid>
   );

--- a/odd-platform-ui/src/components/Terms/TermDetails/TermLinkedTermsList/LinkedTermsList.tsx
+++ b/odd-platform-ui/src/components/Terms/TermDetails/TermLinkedTermsList/LinkedTermsList.tsx
@@ -1,8 +1,10 @@
 import React, { type FC, useState } from 'react';
 import { Grid, Typography } from '@mui/material';
 import InfiniteScroll from 'react-infinite-scroll-component';
+import { useDebouncedCallback } from 'use-debounce';
 import { useTranslation } from 'react-i18next';
 import { AppErrorPage, EmptyContentPlaceholder, Input } from 'components/shared/elements';
+import type { ErrorState } from 'redux/interfaces';
 import { useTermsRouteParams } from 'routes';
 import { useGetTermLinkedTerms } from 'lib/hooks';
 import LinkedTerm from './LinkedTerm/LinkedTerm';
@@ -17,16 +19,20 @@ const LinkedTermsList: FC = () => {
   const { t } = useTranslation();
   const { termId } = useTermsRouteParams();
 
+  // searchText drives the controlled input (immediate); query feeds the query key (debounced),
+  // so typing fires at most ~1 request / 500ms instead of one per keystroke.
+  const [searchText, setSearchText] = useState('');
   const [query, setQuery] = useState('');
+  const debouncedSetQuery = useDebouncedCallback((value: string) => setQuery(value), 500);
 
   const {
     data: termLinks,
     isLoading: isLinkedListFetching,
     isFetched: isLinkedListFetched,
-    fetchNextPage,
-    refetch,
-    hasNextPage,
+    isError,
     error,
+    fetchNextPage,
+    hasNextPage,
   } = useGetTermLinkedTerms({
     termId,
     size: 50,
@@ -34,6 +40,29 @@ const LinkedTermsList: FC = () => {
   });
   const termLinkedList = termLinks?.pages.flatMap(list => list.items);
   const total = termLinks?.pages[0].pageInfo.total;
+
+  const handleSearchChange = (value: string) => {
+    setSearchText(value);
+    debouncedSetQuery(value);
+  };
+
+  const handleSearchSubmit = () => {
+    debouncedSetQuery.cancel();
+    setQuery(searchText);
+  };
+
+  // The generated client throws a ResponseError wrapping the Response — surface the REAL error
+  // instead of the previous hard-coded 500 (which also rendered during normal loading).
+  const errResponse =
+    error instanceof Response ? error : (error as { response?: Response })?.response;
+  const linkedListError: ErrorState | undefined = error
+    ? {
+        status: errResponse?.status ?? 0,
+        statusText: errResponse?.statusText || 'Unknown Error',
+        url: errResponse?.url ?? '',
+        message: error instanceof Error ? error.message : 'Unknown Error',
+      }
+    : undefined;
 
   return (
     <Grid>
@@ -43,11 +72,12 @@ const LinkedTermsList: FC = () => {
             variant='search-m'
             placeholder={t('Search')}
             maxWidth={640}
-            onChange={e => {
-              setQuery(e.target.value);
+            onKeyDown={e => {
+              if (e.key === 'Enter') handleSearchSubmit();
             }}
-            value={query}
-            handleSearchClick={() => refetch()}
+            onChange={e => handleSearchChange(e.target.value)}
+            value={searchText}
+            handleSearchClick={handleSearchSubmit}
           />
         </Grid>
       </Grid>
@@ -80,21 +110,11 @@ const LinkedTermsList: FC = () => {
         )}
       </TermLinkedTermsListContainer>
       <EmptyContentPlaceholder
-        text={t('No linked entities')}
-        isContentLoaded={isLinkedListFetched}
+        text={t('No linked terms')}
+        isContentLoaded={isLinkedListFetched && !isError}
         isContentEmpty={!total}
       />
-      <AppErrorPage
-        showError={!isLinkedListFetched}
-        // FIXME
-        error={{
-          status: 500,
-          statusText: error?.message ?? 'Unknown Error',
-          url: query,
-          message: error?.message ?? 'Unknown Error',
-        }}
-        offsetTop={194}
-      />
+      <AppErrorPage showError={isError} error={linkedListError} offsetTop={194} />
     </Grid>
   );
 };

--- a/odd-platform-ui/src/lib/hooks/api/terms.ts
+++ b/odd-platform-ui/src/lib/hooks/api/terms.ts
@@ -1,14 +1,8 @@
-import {
-  useInfiniteQuery,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { termApi } from 'lib/api';
 import type {
   PageInfo,
   TermApiGetTermByNamespaceAndNameRequest,
-  TermApiGetTermDetailsRequest,
   TermApiGetTermLinkedColumnsRequest,
   TermApiGetTermLinkedTermsRequest,
   TermApiCreateQueryExampleToTermRelationshipRequest,
@@ -17,6 +11,8 @@ import type {
   TermApiAddLinkedTermToTermRequest,
 } from 'generated-sources';
 import { showSuccessToast, type AppError } from 'lib/errorHandling';
+import { useAppDispatch } from 'redux/lib/hooks';
+import { fetchTermDetails } from 'redux/thunks';
 
 export function useGetTermByNamespaceAndName() {
   const queryClient = useQueryClient();
@@ -33,19 +29,23 @@ export function useGetTermByNamespaceAndName() {
   };
 }
 
-export function useGetTermLinkedColumns(params: TermApiGetTermLinkedColumnsRequest) {
-  return useQuery({
-    queryKey: ['termLinkedColumns', params.termId],
-    queryFn: () => termApi.getTermLinkedColumns(params),
-    enabled: false,
-    initialData: { pageInfo: { total: 0, hasNext: false }, items: [] },
-  });
-}
-
-export function useGetTermByID(params: TermApiGetTermDetailsRequest) {
-  return useQuery({
-    queryKey: ['term', params.termId],
-    queryFn: () => termApi.getTermDetails(params),
+export function useGetTermLinkedColumns(
+  params: Omit<TermApiGetTermLinkedColumnsRequest, 'page'>
+) {
+  return useInfiniteQuery({
+    queryKey: ['termLinkedColumns', params.termId, params.size, params.query],
+    queryFn: ({ pageParam }) =>
+      termApi.getTermLinkedColumns({
+        page: pageParam,
+        size: params.size,
+        termId: params.termId,
+        query: params.query,
+      }),
+    initialPageParam: 1,
+    // The backend now returns an honest pageInfo (real total + hasNext) for this endpoint,
+    // so paging is driven by it directly (no client-side full-page heuristic needed).
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.pageInfo.hasNext ? allPages.length + 1 : undefined,
   });
 }
 
@@ -135,7 +135,7 @@ export function useUnassignTermQueryExample() {
 }
 
 export function useAddLinkedTermToTerm({ termId }: { termId: number }) {
-  const queryClient = useQueryClient();
+  const dispatch = useAppDispatch();
   return useMutation({
     mutationFn: async ({
       termId: termIdParam,
@@ -147,15 +147,14 @@ export function useAddLinkedTermToTerm({ termId }: { termId: number }) {
       }),
     onSuccess: async () => {
       showSuccessToast({ message: 'Term successfully added!' });
-      await queryClient.invalidateQueries({
-        queryKey: ['term', termId],
-      });
+      // The Overview linked-terms panel reads term details from redux, so refresh that store.
+      await dispatch(fetchTermDetails({ termId }));
     },
   });
 }
 
 export function useDeleteLinkedTermToTerm({ termId }: { termId: number }) {
-  const queryClient = useQueryClient();
+  const dispatch = useAppDispatch();
   return useMutation({
     mutationFn: async (params: TermApiDeleteLinkedTermFromTermRequest) => {
       await termApi.deleteLinkedTermFromTerm(params);
@@ -163,9 +162,7 @@ export function useDeleteLinkedTermToTerm({ termId }: { termId: number }) {
     },
     onSuccess: async () => {
       showSuccessToast({ message: 'Term successfully deleted!' });
-      await queryClient.invalidateQueries({
-        queryKey: ['term', termId],
-      });
+      await dispatch(fetchTermDetails({ termId }));
     },
   });
 }

--- a/odd-platform-ui/src/locales/translations/br.json
+++ b/odd-platform-ui/src/locales/translations/br.json
@@ -219,6 +219,7 @@
   "No custom metadata": "Sem metadados personalizados",
   "No information to display": "Sem informação para mostrar",
   "No linked entities": "Sem entidades vinculadas",
+  "No linked terms": "Sem termos vinculados",
   "No matches found": "Nenhum resultado encontrado",
   "No messages": "Sem mensagens",
   "No predefined metadata": "Sem metadados pré-definidos",

--- a/odd-platform-ui/src/locales/translations/ch.json
+++ b/odd-platform-ui/src/locales/translations/ch.json
@@ -220,6 +220,7 @@
   "No custom metadata": "尚无自定义元数据",
   "No information to display": "没有信息可显示",
   "No linked entities": "没有关联项",
+  "No linked terms": "没有已链接的术语",
   "No matches found": "未找到匹配项",
   "No messages": "没有消息",
   "No predefined metadata": "没有预定义的元数据",

--- a/odd-platform-ui/src/locales/translations/en.json
+++ b/odd-platform-ui/src/locales/translations/en.json
@@ -223,6 +223,7 @@
   "No custom metadata": "No custom metadata",
   "No information to display": "No information to display",
   "No linked entities": "No linked entities",
+  "No linked terms": "No linked terms",
   "No matches found": "No matches found",
   "No messages": "No messages",
   "No predefined metadata": "No predefined metadata",

--- a/odd-platform-ui/src/locales/translations/es.json
+++ b/odd-platform-ui/src/locales/translations/es.json
@@ -220,6 +220,7 @@
   "No custom metadata": "Sin metadatos personalizados",
   "No information to display": "Sin información para mostrar",
   "No linked entities": "Sin ítems enlazados",
+  "No linked terms": "Sin términos vinculados",
   "No matches found": "No se encontraron resultados",
   "No messages": "Sin mensajes",
   "No predefined metadata": "Sin metadatos predefinidos",

--- a/odd-platform-ui/src/locales/translations/fr.json
+++ b/odd-platform-ui/src/locales/translations/fr.json
@@ -220,6 +220,7 @@
   "No custom metadata": "Pas de métadonnées personnalisées",
   "No information to display": "Aucune information à afficher",
   "No linked entities": "Aucun élément lié",
+  "No linked terms": "Aucun terme lié",
   "No matches found": "Aucune correspondance trouvée",
   "No messages": "Aucun message",
   "No predefined metadata": "Aucune métadonnée prédéfinie",

--- a/odd-platform-ui/src/locales/translations/hy.json
+++ b/odd-platform-ui/src/locales/translations/hy.json
@@ -220,6 +220,7 @@
   "No custom metadata": "Հատուկ մետատվյալ չկա",
   "No information to display": "Ցույց տալու տեղեկություն չկա",
   "No linked entities": "Կապակցված տարրեր չկան",
+  "No linked terms": "Կապված տերմիններ չկան",
   "No matches found": "Համընկնումներ չեն գտնվել",
   "No messages": "Հաղորդագրություններ չկան",
   "No predefined metadata": "Նախապես սահմանված մետատվյալ չկա",

--- a/odd-platform-ui/src/locales/translations/ua.json
+++ b/odd-platform-ui/src/locales/translations/ua.json
@@ -223,6 +223,7 @@
   "No custom metadata": "Немає користувацьких метаданих",
   "No information to display": "Немає інформації для відображення",
   "No linked entities": "Немає зв'язаних елементів",
+  "No linked terms": "Немає пов’язаних термінів",
   "No matches found": "Співпадінь не знайдено",
   "No messages": "Немає повідомлень",
   "No predefined metadata": "Немає попередньо визначених метаданих",


### PR DESCRIPTION
…,6,7)

Resolves six Term Detail page defects from #1754 (the deferred 3 & 8 are tracked in PLT-235/PLT-236). Each fix conforms to an existing sibling/pattern on the page.

- D1: Overview reads the shell's redux term-details + permissions instead of a second GET /api/terms/{id} (the 13-JOIN hot path); the linked-term add/delete mutations dispatch a redux fetchTermDetails so the Overview panel still refreshes.
- D2: TermDetailsTabs no longer hides the Linked entities/columns/terms tabs at zero count — they are always shown (count badge incl. 0), so linking is discoverable.
- D4: LinkedColumnsList migrates to useInfiniteQuery + wired fetchNextPage (was a pinned page + a noop InfiniteScroll next); the backend page_info now reports the REAL total + hasNext (new ReactiveDatasetFieldRepository.countByTerm; the service zips the page with the count; DatasetFieldListMapperImpl computes hasNext). A term with 60 linked columns shows all 60; the tab badge no longer disagrees with the list.
- D5: LinkedTermsList renders AppErrorPage on a real error (mapped from the response) and gates the empty state on !isError — no synthesised 500 during loading, real failures no longer read as "empty".
- D6: the Linked Terms empty copy reads "No linked terms" (was the copy-pasted "No linked entities"); the key is added to all 7 locales.
- D7: the Linked Terms search is debounced (500ms) + Enter-submittable, mirroring LinkedEntitiesList.

Verified on a running stack (curl + Playwright, before/after) and by unit + integration tests. Backend page_info: D4 implemented with a dedicated countByTerm query rather than the pageifyResult window pattern — the complex CTE+groupBy list query's name-based mapper extraction makes wrapping it in paginate risky; the separate count yields the same honest page_info with lower regression risk.

Scope EXCLUDES (G-C5): defect 3 (dual-surface — product decision, PLT-235), defect 8 (state-pattern unification — needs an ADR, PLT-236), the orphan-column linked-columns NPE (PLT-237). No DB migration, no OpenAPI/client regeneration, no auth-posture change.

Tests: unit — DatasetFieldServiceImplTest.listByTerm + DatasetFieldListMapperImplTest (page_info math); integration (odd-team) — IT-139 (new), IT-032 (+D1/D2), IT-082 (+D5/D7, re-grounded D6 pin). GREEN on the fix, RED on origin/main.

Consumer-read: odd-platform-ui TermDetails.tsx (shell fetchTermDetails+permissions), Overview.tsx, TermDetailsTabs.tsx + shared AppTabs/AppTabLabel.tsx (hint render), LinkedColumnsList.tsx, LinkedTermsList.tsx, LinkedEntitiesList.tsx (sibling pattern), lib/hooks/api/terms.ts, redux/slices/terms.slice.ts + selectors/terms.selectors.ts (redux term-details shape), Overview/TermLinkedTerms/TermLinkedTerms.tsx + TermItem + LinkedTermTermForm (mutation refresh), shared AppErrorPage.tsx + EmptyContentPlaceholder.tsx
+ lib/errorHandling.tsx + redux/interfaces (ErrorState); odd-platform-api TermController.getTermLinkedColumns, DatasetFieldServiceImpl.listByTerm, ReactiveDatasetFieldRepositoryImpl.listByTerm, repository/mapper/DatasetFieldTermsDtoMapper, mapper/DatasetFieldListMapperImpl, repository/util/JooqQueryHelper (pageifyResult/paginate), service/DataEntityServiceImpl.listByTerm (honest-pagination reference).

Sources: odd-platform#1754 (issue body, quoted as data); reproduced live 2026-06-22 on odd-platform:odd-team-sut; verified GREEN on the working-tree SUT, RED on origin/main.

**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**

**How to test**