### PR TITLE
fix(ui): reflect alert status change without refresh + confirm before…

### DIFF
--- a/odd-platform-ui/src/components/Alerts/AlertsList/AlertItem/AlertItem.tsx
+++ b/odd-platform-ui/src/components/Alerts/AlertsList/AlertItem/AlertItem.tsx
@@ -7,7 +7,12 @@ import { useAppDispatch, useAppSelector } from 'redux/lib/hooks';
 import { fetchResourcePermissions, updateAlertStatus } from 'redux/thunks';
 import { useAppDateTime } from 'lib/hooks';
 import { GearIcon, UserIcon } from 'components/shared/icons';
-import { AlertStatusItem, Button, EntityClassItem } from 'components/shared/elements';
+import {
+  AlertStatusItem,
+  Button,
+  ConfirmationDialog,
+  EntityClassItem,
+} from 'components/shared/elements';
 import { alertTitlesMap } from 'lib/constants';
 import { getGlobalPermissions } from 'redux/selectors';
 import { dataEntityDetailsPath } from 'routes';
@@ -34,41 +39,37 @@ const AlertItem: React.FC<AlertItemProps> = ({
   const { t } = useTranslation();
 
   const [showHistory, setShowHistory] = React.useState(false);
-  const [disableResolve, setDisableResolve] = React.useState(false);
-  const [isUpdating, setIsUpdating] = React.useState(false);
 
   const globalPermissions = useAppSelector(getGlobalPermissions);
 
-  const dispatchUpdateAlertStatus = () => {
-    const status =
-      alertStatus === AlertStatus.OPEN ? AlertStatus.RESOLVED : AlertStatus.OPEN;
-    dispatch(updateAlertStatus({ alertId: id, alertStatusFormData: { status } })).then(
-      () => setIsUpdating(false)
-    );
-  };
+  const isOpen = alertStatus === AlertStatus.OPEN;
 
-  const handleResolve = () => {
-    if (dataEntity?.id) {
-      const params = {
+  // The global Alerts page lists alerts across entities, so DATA_ENTITY_ALERT_RESOLVE is checked per entity
+  // at confirm time. Both the permission check and the status change use `.unwrap()` so a denial / failure
+  // REJECTS the dialog's onConfirm — surfaced inline, the dialog stays open — instead of resolving and
+  // closing as success (odd-platform#1766 / CTRIB-031 idiom). The ConfirmationDialog renders its own loading
+  // + error state, so the previous bespoke isUpdating / disableResolve / "No access!" caption is gone.
+  const onConfirmStatusChange = async () => {
+    if (!dataEntity?.id) return;
+    const { permissions } = await dispatch(
+      fetchResourcePermissions({
         resourceId: dataEntity.id,
         permissionResourceType: PermissionResourceType.DATA_ENTITY,
-      };
-      setIsUpdating(true);
-      dispatch(fetchResourcePermissions(params))
-        .unwrap()
-        .then(({ permissions }) => {
-          if (
-            [...globalPermissions, ...permissions].includes(
-              Permission.DATA_ENTITY_ALERT_RESOLVE
-            )
-          ) {
-            dispatchUpdateAlertStatus();
-          } else {
-            setIsUpdating(false);
-            setDisableResolve(true);
-          }
-        });
+      })
+    ).unwrap();
+    if (
+      ![...globalPermissions, ...permissions].includes(
+        Permission.DATA_ENTITY_ALERT_RESOLVE
+      )
+    ) {
+      // getErrorResponse reads a Response body's `message`, so a thrown Response surfaces "No access!"
+      // in the dialog without a shared-util change.
+      throw new Response(JSON.stringify({ message: t('No access!') }), { status: 403 });
     }
+    const status = isOpen ? AlertStatus.RESOLVED : AlertStatus.OPEN;
+    await dispatch(
+      updateAlertStatus({ alertId: id, alertStatusFormData: { status } })
+    ).unwrap();
   };
 
   const resolvedInfo = React.useMemo(() => {
@@ -157,17 +158,23 @@ const AlertItem: React.FC<AlertItemProps> = ({
           {resolvedInfo}
           <AlertStatusItem status={alertStatus} />
           <Grid display='flex' flexDirection='column' alignItems='center' sx={{ ml: 2 }}>
-            <Button
-              text={alertStatus === 'OPEN' ? t('Resolve') : t('Reopen')}
-              sx={{ minWidth: '72px !important', minHeight: '24px' }}
-              buttonType='secondary-m'
-              onClick={handleResolve}
-              disabled={disableResolve}
-              isLoading={isUpdating}
+            <ConfirmationDialog
+              actionTitle={isOpen ? t('Resolve') : t('Reopen')}
+              actionName={isOpen ? t('Resolve') : t('Reopen')}
+              actionText={
+                isOpen
+                  ? t('Are you sure you want to resolve this alert?')
+                  : t('Are you sure you want to reopen this alert?')
+              }
+              onConfirm={onConfirmStatusChange}
+              actionBtn={
+                <Button
+                  text={isOpen ? t('Resolve') : t('Reopen')}
+                  sx={{ minWidth: '72px !important', minHeight: '24px' }}
+                  buttonType='secondary-m'
+                />
+              }
             />
-            {disableResolve && (
-              <Typography variant='caption'>{t('No access!')}</Typography>
-            )}
           </Grid>
         </S.Wrapper>
       </Grid>

--- a/odd-platform-ui/src/components/DataEntityDetails/DataEntityAlerts/DataEntityAlertItem/DataEntityAlertItem.tsx
+++ b/odd-platform-ui/src/components/DataEntityDetails/DataEntityAlerts/DataEntityAlertItem/DataEntityAlertItem.tsx
@@ -6,7 +6,7 @@ import { AlertStatus, Permission } from 'generated-sources';
 import { useAppDateTime } from 'lib/hooks';
 import { updateAlertStatus } from 'redux/thunks';
 import { useAppDispatch } from 'redux/lib/hooks';
-import { AlertStatusItem, Button } from 'components/shared/elements';
+import { AlertStatusItem, Button, ConfirmationDialog } from 'components/shared/elements';
 import { WithPermissions } from 'components/shared/contexts';
 import { GearIcon, UserIcon } from 'components/shared/icons';
 import { alertTitlesMap } from 'lib/constants';
@@ -35,12 +35,18 @@ const DataEntityAlertItem: React.FC<DataEntityAlertItemProps> = ({
 
   const [showHistory, setShowHistory] = React.useState(false);
 
-  const alertStatusHandler = () => {
-    const status =
-      alertStatus === AlertStatus.OPEN ? AlertStatus.RESOLVED : AlertStatus.OPEN;
-    const params = { alertId, alertStatusFormData: { status }, entityId: dataEntityId };
-
-    dispatch(updateAlertStatus(params));
+  const isOpen = alertStatus === AlertStatus.OPEN;
+  const onConfirmStatusChange = () => {
+    const status = isOpen ? AlertStatus.RESOLVED : AlertStatus.OPEN;
+    // `.unwrap()` so a failed status change REJECTS the dialog's onConfirm (surfaced inline, dialog stays
+    // open) instead of resolving and closing as success (odd-platform#1766 / CTRIB-031 idiom).
+    return dispatch(
+      updateAlertStatus({
+        alertId,
+        alertStatusFormData: { status },
+        entityId: dataEntityId,
+      })
+    ).unwrap();
   };
 
   const resolvedInfo = React.useMemo(() => {
@@ -110,11 +116,22 @@ const DataEntityAlertItem: React.FC<DataEntityAlertItemProps> = ({
           <AlertStatusItem status={alertStatus} />
           <WithPermissions permissionTo={Permission.DATA_ENTITY_ALERT_RESOLVE}>
             <Grid>
-              <Button
-                text={alertStatus === 'OPEN' ? t('Resolve') : t('Reopen')}
-                sx={{ ml: 2 }}
-                buttonType='secondary-m'
-                onClick={alertStatusHandler}
+              <ConfirmationDialog
+                actionTitle={isOpen ? t('Resolve') : t('Reopen')}
+                actionName={isOpen ? t('Resolve') : t('Reopen')}
+                actionText={
+                  isOpen
+                    ? t('Are you sure you want to resolve this alert?')
+                    : t('Are you sure you want to reopen this alert?')
+                }
+                onConfirm={onConfirmStatusChange}
+                actionBtn={
+                  <Button
+                    text={isOpen ? t('Resolve') : t('Reopen')}
+                    sx={{ ml: 2 }}
+                    buttonType='secondary-m'
+                  />
+                }
               />
             </Grid>
           </WithPermissions>

--- a/odd-platform-ui/src/locales/translations/br.json
+++ b/odd-platform-ui/src/locales/translations/br.json
@@ -636,5 +636,7 @@
   "Warning": "Aviso",
   "Open": "Aberto",
   "Resolved automatically": "Resolvido automaticamente",
-  "Showing {{visible}} of {{total}}": "Mostrando {{visible}} de {{total}}"
+  "Showing {{visible}} of {{total}}": "Mostrando {{visible}} de {{total}}",
+  "Are you sure you want to resolve this alert?": "Tem certeza de que deseja resolver este alerta?",
+  "Are you sure you want to reopen this alert?": "Tem certeza de que deseja reabrir este alerta?"
 }

--- a/odd-platform-ui/src/locales/translations/ch.json
+++ b/odd-platform-ui/src/locales/translations/ch.json
@@ -636,5 +636,7 @@
   "Warning": "警告",
   "Open": "打开",
   "Resolved automatically": "已自动解决",
-  "Showing {{visible}} of {{total}}": "显示 {{total}} 中的 {{visible}}"
+  "Showing {{visible}} of {{total}}": "显示 {{total}} 中的 {{visible}}",
+  "Are you sure you want to resolve this alert?": "您确定要解决此警报吗？",
+  "Are you sure you want to reopen this alert?": "您确定要重新打开此警报吗？"
 }

--- a/odd-platform-ui/src/locales/translations/en.json
+++ b/odd-platform-ui/src/locales/translations/en.json
@@ -636,5 +636,7 @@
   "Warning": "Warning",
   "Open": "Open",
   "Resolved automatically": "Resolved automatically",
-  "Showing {{visible}} of {{total}}": "Showing {{visible}} of {{total}}"
+  "Showing {{visible}} of {{total}}": "Showing {{visible}} of {{total}}",
+  "Are you sure you want to resolve this alert?": "Are you sure you want to resolve this alert?",
+  "Are you sure you want to reopen this alert?": "Are you sure you want to reopen this alert?"
 }

--- a/odd-platform-ui/src/locales/translations/es.json
+++ b/odd-platform-ui/src/locales/translations/es.json
@@ -636,5 +636,7 @@
   "Warning": "Advertencia",
   "Open": "Abierto",
   "Resolved automatically": "Resuelto automáticamente",
-  "Showing {{visible}} of {{total}}": "Mostrando {{visible}} de {{total}}"
+  "Showing {{visible}} of {{total}}": "Mostrando {{visible}} de {{total}}",
+  "Are you sure you want to resolve this alert?": "¿Realmente quieres resolver esta alerta?",
+  "Are you sure you want to reopen this alert?": "¿Realmente quieres reabrir esta alerta?"
 }

--- a/odd-platform-ui/src/locales/translations/fr.json
+++ b/odd-platform-ui/src/locales/translations/fr.json
@@ -636,5 +636,7 @@
   "Warning": "Avertissement",
   "Open": "Ouvert",
   "Resolved automatically": "Résolu automatiquement",
-  "Showing {{visible}} of {{total}}": "Affichage de {{visible}} sur {{total}}"
+  "Showing {{visible}} of {{total}}": "Affichage de {{visible}} sur {{total}}",
+  "Are you sure you want to resolve this alert?": "Êtes-vous sûr de vouloir résoudre cette alerte ?",
+  "Are you sure you want to reopen this alert?": "Êtes-vous sûr de vouloir réouvrir cette alerte ?"
 }

--- a/odd-platform-ui/src/locales/translations/hy.json
+++ b/odd-platform-ui/src/locales/translations/hy.json
@@ -636,5 +636,7 @@
   "Warning": "Զգուշացում",
   "Open": "Բաց",
   "Resolved automatically": "Հանգուցալուծված ինքնաշխատ կերպով",
-  "Showing {{visible}} of {{total}}": "Ցուցադրվում է {{visible}}-ը {{total}}-ից"
+  "Showing {{visible}} of {{total}}": "Ցուցադրվում է {{visible}}-ը {{total}}-ից",
+  "Are you sure you want to resolve this alert?": "Դուք վստա՞հ եք, որ ուզում եք հանգուցալուծել այս ազդանշանը։",
+  "Are you sure you want to reopen this alert?": "Դուք վստա՞հ եք, որ ուզում եք վերաբացել այս ազդանշանը։"
 }

--- a/odd-platform-ui/src/locales/translations/ua.json
+++ b/odd-platform-ui/src/locales/translations/ua.json
@@ -636,5 +636,7 @@
   "Warning": "Попередження",
   "Open": "Відкрито",
   "Resolved automatically": "Вирішено автоматично",
-  "Showing {{visible}} of {{total}}": "Показано {{visible}} з {{total}}"
+  "Showing {{visible}} of {{total}}": "Показано {{visible}} з {{total}}",
+  "Are you sure you want to resolve this alert?": "Ви дійсно хочете вирішити це сповіщення?",
+  "Are you sure you want to reopen this alert?": "Ви дійсно хочете знову відкрити це сповіщення?"
 }

--- a/odd-platform-ui/src/redux/slices/__tests__/alerts.slice.test.ts
+++ b/odd-platform-ui/src/redux/slices/__tests__/alerts.slice.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { AlertStatus } from 'generated-sources';
+import type { Alert } from 'redux/interfaces';
+import reducer, { initialState } from 'redux/slices/alerts.slice';
+import { updateAlertStatus } from 'redux/thunks';
+
+/**
+ * odd-platform#1803 (CTRIB-034) Defect 1 — a status change made from the per-entity Data Entity > Alerts
+ * tab must be reflected in `state.dataEntityAlerts[id].items` WITHOUT a refetch. Pre-fix, the
+ * `updateAlertStatus` thunk returned the entity id under the key `dataEntityId` while the reducer reads
+ * `entityId`, so the `if (dataEntityId)` per-entity branch was unreachable and the write fell through to the
+ * global `state.alerts.items` (which the per-entity tab does not render) — the row stayed stale until reload.
+ *
+ * The bug is in the THUNK's emitted key, not the reducer (the reducer correctly reads `entityId`). So this
+ * test runs the REAL thunk (mocking only the API boundary) to exercise the emitted payload, then feeds the
+ * resulting action to the REAL reducer — a hand-crafted `.fulfilled({ entityId })` payload would pass on the
+ * buggy system too and prove nothing. RED on pre-fix `dataEntityId:`; GREEN on `entityId:`.
+ */
+
+// vi.mock is hoisted above all imports, so `redux/thunks` (and its transitive `lib/api`) load mocked.
+const { changeAlertStatus } = vi.hoisted(() => ({ changeAlertStatus: vi.fn() }));
+vi.mock('lib/api', () => ({ alertApi: { changeAlertStatus }, dataEntityApi: {} }));
+vi.mock('lib/errorHandling', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, showSuccessToast: vi.fn(), showServerErrorToast: vi.fn() };
+});
+
+const ENTITY_ID = 2001;
+const openAlert = { id: 7, status: AlertStatus.OPEN } as unknown as Alert;
+const resolvedAlert = { id: 7, status: AlertStatus.RESOLVED } as unknown as Alert;
+
+const runThunk = (arg: Parameters<typeof updateAlertStatus>[0]) =>
+  updateAlertStatus(arg)(vi.fn(), () => ({}), undefined);
+
+describe('alerts slice — updateAlertStatus reflects a status change without a refetch (#1803)', () => {
+  beforeEach(() => {
+    changeAlertStatus.mockReset();
+    changeAlertStatus.mockResolvedValue(resolvedAlert);
+  });
+
+  it('Defect 1 — a per-entity resolve updates state.dataEntityAlerts[id].items IN PLACE', async () => {
+    const action = await runThunk({
+      alertId: 7,
+      alertStatusFormData: { status: AlertStatus.RESOLVED },
+      entityId: ENTITY_ID,
+    });
+
+    // the fulfilled payload must carry the entity id under the key the reducer reads
+    expect(action.type).toMatch(/fulfilled$/);
+    expect((action.payload as { entityId?: number }).entityId).toBe(ENTITY_ID);
+
+    const start = {
+      ...initialState,
+      dataEntityAlerts: {
+        [ENTITY_ID]: {
+          items: [openAlert],
+          pageInfo: { total: 1, page: 1, hasNext: false },
+          alertCount: 1,
+        },
+      },
+    } as ReturnType<typeof reducer>;
+
+    const next = reducer(start, action);
+
+    // the per-entity list the tab renders now shows the new status — no refetch needed
+    expect(next.dataEntityAlerts[ENTITY_ID].items[0].status).toBe(AlertStatus.RESOLVED);
+  });
+
+  it('the global Alerts page (no entity id) still updates state.alerts.items in place', async () => {
+    const action = await runThunk({
+      alertId: 7,
+      alertStatusFormData: { status: AlertStatus.RESOLVED },
+    });
+
+    const start = {
+      ...initialState,
+      alerts: { ...initialState.alerts, items: [openAlert] },
+    } as ReturnType<typeof reducer>;
+
+    const next = reducer(start, action);
+
+    expect(next.alerts.items[0].status).toBe(AlertStatus.RESOLVED);
+  });
+});

--- a/odd-platform-ui/src/redux/thunks/alerts.thunks.ts
+++ b/odd-platform-ui/src/redux/thunks/alerts.thunks.ts
@@ -75,7 +75,11 @@ export const updateAlertStatus = handleResponseAsyncThunk<
   async params => {
     const alert = await alertApi.changeAlertStatus(params);
 
-    return { alert: castDatesToTimestamp(alert), dataEntityId: params.entityId };
+    // Emit the entity id under `entityId` — the key the reducer (and the sibling fetchDataEntityAlerts*
+    // thunks) read, and the one `Partial<EntityId>` declares. Pre-fix this returned `dataEntityId`, so the
+    // reducer's per-entity branch never ran and a per-entity resolve fell through to the global list
+    // (odd-platform#1803): the Data Entity > Alerts tab stayed stale until a refetch.
+    return { alert: castDatesToTimestamp(alert), entityId: params.entityId };
   },
   {
     setSuccessOptions: ({ alertStatusFormData, alertId }) => ({


### PR DESCRIPTION
… flipping (#1803)

Two front-end defects in the alert status-change flow:

Defect 1 — the per-entity Data Entity > Alerts tab did not reflect a Resolve/Reopen until a page refresh. The updateAlertStatus thunk returned the entity id under the key `dataEntityId` while the reducer reads `entityId`, so the per-entity update branch was unreachable and the write fell through to the global `state.alerts.items` (which the tab does not render). Fix: emit `entityId` — the key the reducer and the sibling fetchDataEntityAlerts* thunks already use, and the one `Partial<EntityId>` declares.

Defect 2 — no confirmation before the flip on either surface. Fix: wrap the Resolve/ Reopen trigger in the existing ConfirmationDialog on both the per-entity tab and the global Alerts page, with `.unwrap()` on the dispatched thunk so a failed status change surfaces in the dialog instead of closing as success (the #1766 idiom). On the global page the per-entity permission pre-fetch is folded into onConfirm, so the dialog's own loading/error state replaces the bespoke isUpdating/disableResolve/'No access!' state.

Tests: a redux store unit test that runs the real thunk through the real reducer and asserts the per-entity slice updates in place (RED on the pre-fix `dataEntityId` key). New confirmation strings added to all 7 locale catalogs.

**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**

**How to test**