### PR TITLE
test(housekeeping): prove alert retention behaviourally; drop the fal…

### DIFF
--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/housekeeping/AlertHousekeepingRetentionTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/housekeeping/AlertHousekeepingRetentionTest.java
@@ -1,0 +1,131 @@
+package org.opendatadiscovery.oddplatform.housekeeping;
+
+import java.sql.Connection;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.opendatadiscovery.oddplatform.BaseIntegrationTest;
+import org.opendatadiscovery.oddplatform.dto.alert.AlertStatusEnum;
+import org.opendatadiscovery.oddplatform.dto.alert.AlertTypeEnum;
+import org.opendatadiscovery.oddplatform.housekeeping.config.HousekeepingTTLProperties;
+import org.opendatadiscovery.oddplatform.housekeeping.job.AlertHousekeepingJob;
+import org.opendatadiscovery.oddplatform.model.tables.pojos.AlertChunkPojo;
+import org.opendatadiscovery.oddplatform.model.tables.pojos.AlertPojo;
+import org.opendatadiscovery.oddplatform.model.tables.pojos.DataEntityPojo;
+import org.opendatadiscovery.oddplatform.model.tables.pojos.DataSourcePojo;
+import org.opendatadiscovery.oddplatform.notification.PGConnectionFactory;
+import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveAlertRepository;
+import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveDataEntityRepository;
+import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveDataSourceRepository;
+import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveNamespaceRepository;
+import org.opendatadiscovery.oddplatform.service.ingestion.util.DateTimeUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opendatadiscovery.oddplatform.model.Tables.ALERT;
+
+/**
+ * Behavioural test for {@link AlertHousekeepingJob} retention — it runs the REAL job against a real Postgres
+ * and asserts the actual deletion outcome (not a hand-written predicate replica, not a source-text scan).
+ *
+ * <p>PLT-005 claimed the job's {@code .where(A).or(B).and(C)} chain evaluates as {@code A OR (B AND C)}, so a
+ * freshly manually-RESOLVED alert would be hard-deleted regardless of {@code resolved_alerts_days}. That is a
+ * misread of jOOQ as raw SQL: jOOQ DSL chaining is left-associative and parenthesised, so the job emits
+ * {@code (A OR B) AND C} — only resolved alerts PAST the retention window are deleted. This test proves it:
+ * it is GREEN on the current code and would be RED only if the job actually purged a fresh manual-RESOLVED
+ * alert (the alleged bug). Manual and automatic resolutions are retained symmetrically.
+ *
+ * <p>The TTL is pinned to 30 explicitly so this test is independent of the separate PLT-083 zero-default
+ * (an unset {@code resolved_alerts_days} binds to {@code 0} → {@code now.minusDays(0) = now} → everything is
+ * deleted, which is a different defect on the same job).
+ */
+@DisplayName("AlertHousekeepingJob retention respects resolved_alerts_days (PLT-005 is not a bug)")
+class AlertHousekeepingRetentionTest extends BaseIntegrationTest {
+
+    private static final int TTL_DAYS = 30;
+
+    @Autowired
+    private ReactiveAlertRepository alertRepository;
+    @Autowired
+    private ReactiveDataEntityRepository dataEntityRepository;
+    @Autowired
+    private ReactiveDataSourceRepository dataSourceRepository;
+    @Autowired
+    private ReactiveNamespaceRepository namespaceRepository;
+    @Autowired
+    private PGConnectionFactory pgConnectionFactory;
+
+    @Test
+    void freshlyResolvedAlertsAreRetained_onlyAgedOnesArePurged() throws Exception {
+        final HousekeepingTTLProperties ttl = new HousekeepingTTLProperties();
+        ttl.setResolvedAlertsDays(TTL_DAYS);
+        final AlertHousekeepingJob job = new AlertHousekeepingJob(ttl);
+
+        final long ns = namespaceRepository.createByName(uuid()).block().getId();
+        final long ds = dataSourceRepository.create(
+            new DataSourcePojo().setOddrn(uuid()).setName(uuid()).setNamespaceId(ns)).block().getId();
+        final String oddrn = uuid();
+        dataEntityRepository.bulkCreate(List.of(new DataEntityPojo()
+                .setOddrn(oddrn).setExternalName(uuid()).setDataSourceId(ds).setNamespaceId(ns)))
+            .collectList().block();
+
+        final LocalDateTime now = DateTimeUtil.generateNow();
+        final LocalDateTime aged = now.minusDays(TTL_DAYS + 1L);
+
+        // freshManual is the PLT-005 discriminator: with the alleged "A OR (B AND C)" bug it would be purged
+        // (branch A matches on status alone); with the real "(A OR B) AND C" predicate it lives its full TTL.
+        final long freshManual = seedAlert(oddrn, AlertStatusEnum.RESOLVED, AlertTypeEnum.FAILED_DQ_TEST, now);
+        final long agedManual = seedAlert(oddrn, AlertStatusEnum.RESOLVED, AlertTypeEnum.FAILED_DQ_TEST, aged);
+        final long freshAuto = seedAlert(oddrn, AlertStatusEnum.RESOLVED_AUTOMATICALLY, AlertTypeEnum.FAILED_JOB, now);
+        final long agedAuto = seedAlert(oddrn, AlertStatusEnum.RESOLVED_AUTOMATICALLY, AlertTypeEnum.FAILED_JOB, aged);
+        final long openFresh =
+            seedAlert(oddrn, AlertStatusEnum.OPEN, AlertTypeEnum.BACKWARDS_INCOMPATIBLE_SCHEMA, now);
+
+        try (final Connection connection = pgConnectionFactory.getConnection()) {
+            job.doHousekeeping(connection);
+        }
+
+        final Set<Long> seeded = Set.of(freshManual, agedManual, freshAuto, agedAuto, openFresh);
+        final Set<Long> surviving = survivingAlertIds(seeded);
+
+        assertThat(surviving)
+            .as("PLT-005 is NOT a bug: a freshly manually-RESOLVED alert (and a fresh auto-resolved one) are "
+                + "retained for the full %d-day window; an OPEN alert is never purged.", TTL_DAYS)
+            .contains(freshManual, freshAuto, openFresh);
+        assertThat(surviving)
+            .as("retention works: resolved alerts PAST the %d-day window are hard-deleted (both manual and auto).",
+                TTL_DAYS)
+            .doesNotContain(agedManual, agedAuto);
+    }
+
+    private long seedAlert(final String oddrn, final AlertStatusEnum status, final AlertTypeEnum type,
+                           final LocalDateTime statusUpdatedAt) {
+        final long alertId = alertRepository.createAlerts(List.of(new AlertPojo()
+                .setDataEntityOddrn(oddrn)
+                .setStatus(status.getCode())
+                .setType(type.getCode())
+                .setLastCreatedAt(statusUpdatedAt)
+                .setStatusUpdatedAt(statusUpdatedAt)))
+            .collectList().block().get(0).getId();
+        alertRepository.createChunks(List.of(new AlertChunkPojo()
+            .setAlertId(alertId).setDescription(uuid()).setCreatedAt(statusUpdatedAt))).block();
+        return alertId;
+    }
+
+    private Set<Long> survivingAlertIds(final Set<Long> candidateIds) throws Exception {
+        try (final Connection connection = pgConnectionFactory.getConnection()) {
+            return new HashSet<>(DSL.using(connection)
+                .select(ALERT.ID).from(ALERT).where(ALERT.ID.in(candidateIds))
+                .fetch(ALERT.ID));
+        }
+    }
+
+    private static String uuid() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/housekeeping/HousekeepingTtlKnownBugsTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/housekeeping/HousekeepingTtlKnownBugsTest.java
@@ -7,8 +7,8 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Known-bug characterization pins for the housekeeping TTL data-loss class — PLT-083 and PLT-005.
- * Both assert the CURRENT (incorrect) behaviour: GREEN while the bug exists, RED the instant the
+ * Known-bug characterization pin for the housekeeping TTL zero-default footgun — PLT-083.
+ * It asserts the CURRENT source shape: GREEN while the footgun exists, RED the instant the
  * code changes. See retrospectives/LSN-029 for the general rule + flip protocol.
  *
  * <p>PLT-083 (LSN-001 shape, F-010 H-002) — {@code HousekeepingTTLProperties} holds bare primitive
@@ -17,24 +17,22 @@ import org.junit.jupiter.api.Test;
  * {@code application.yml} override silently wipes all retained data within 15 minutes. The fix is a
  * sane non-zero default (or an unset≠0 guard). Flip on RED: confirm the default fix, drop this pin.
  *
- * <p>PLT-005 (F-010 H-001) — {@code AlertHousekeepingJob} chains {@code .where(A).or(B).and(C)},
- * which SQL precedence (AND binds tighter than OR) evaluates as {@code A OR (B AND C)} — NOT the
- * intended {@code (A OR B) AND C}. So manually-RESOLVED alerts (branch A) are hard-deleted next
- * cycle regardless of {@code resolved_alerts_days}. The fix groups the OR
- * ({@code .where(A.or(B)).and(C)} or {@code STATUS.in(...)}). Flip on RED: confirm the grouping fix,
- * drop this pin.
+ * <p>PLT-005 (the {@code AlertHousekeepingJob} {@code .or()/.and()} precedence claim) was FALSIFIED and
+ * is NOT pinned here: jOOQ DSL chaining renders {@code .where(A).or(B).and(C)} as {@code (A OR B) AND C}
+ * (the intended grouping), not {@code A OR (B AND C)}, so manual and auto resolutions respect the TTL
+ * symmetrically. The behaviour is proven by {@code AlertHousekeepingRetentionTest} (it runs the real job
+ * against a real Postgres). The earlier source-scan pin asserted a non-bug and was removed. See
+ * issues/odd-platform/PLT-005.md (status: rejected).
  *
- * <p>Idiom: source scan of the real config + job — deterministic, no Spring context; gradle runs
+ * <p>Idiom: source scan of the real config — deterministic, no Spring context; gradle runs
  * tests with the module root as the working dir.
  *
  * @pins PLT-083
- * @pins PLT-005
  */
 class HousekeepingTtlKnownBugsTest {
 
     private static final String BASE = "src/main/java/org/opendatadiscovery/oddplatform/housekeeping/";
     private static final Path TTL_PROPS = Path.of(BASE + "config/HousekeepingTTLProperties.java");
-    private static final Path ALERT_JOB = Path.of(BASE + "job/AlertHousekeepingJob.java");
 
     private static String read(final Path p) throws IOException {
         Assertions.assertThat(Files.exists(p))
@@ -56,16 +54,5 @@ class HousekeepingTtlKnownBugsTest {
             .contains("private int searchFacetsDays;")
             .contains("private int dataEntityDeleteDays;")
             .doesNotContain("@DefaultValue");
-    }
-
-    @Test
-    void alertHousekeepingOrAndPrecedence_knownBug_PLT005() throws IOException {
-        Assertions.assertThat(read(ALERT_JOB))
-            .as("PLT-005: the ungrouped .where(A).or(B).and(C) chain evaluates as A OR (B AND C) — so "
-                + "manually-RESOLVED alerts are deleted regardless of resolved_alerts_days. RED here = the OR "
-                + "was grouped (the fix); confirm and drop this @pins. See retrospectives/LSN-029.")
-            .contains(".where(ALERT.STATUS.eq(AlertStatusEnum.RESOLVED.getCode()))")
-            .contains(".or(ALERT.STATUS.eq(AlertStatusEnum.RESOLVED_AUTOMATICALLY.getCode()))")
-            .contains(".and(ALERT.STATUS_UPDATED_AT.lessOrEqual(");
     }
 }


### PR DESCRIPTION
…sified PLT-005 source-scan pin

PLT-005 claimed AlertHousekeepingJob's .where(A).or(B).and(C) chain is an operator- precedence bug deleting manual-RESOLVED alerts regardless of resolved_alerts_days. It is not: jOOQ renders the chain as '(A OR B) AND C' (the intended grouping). This was falsified on disk in 2026-06-10 (PLT-005.md status:rejected) but never had a runtime test and the false caveat had shipped to the docs.

- Add AlertHousekeepingRetentionTest: runs the REAL AlertHousekeepingJob.doHousekeeping() against a real Postgres (Testcontainers) with TTL=30 — a fresh manual-RESOLVED alert is retained, only aged resolved alerts (manual + auto) are purged. GREEN; RED only if the alleged bug existed.
- Drop the false HousekeepingTtlKnownBugsTest.alertHousekeepingOrAndPrecedence_knownBug_PLT005 source-scan pin (it asserted the chain text and called it buggy). Keep the separate PLT-083 zero-default pin.

**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**

**How to test**