### PR TITLE
Add DataSteward, DataViewer, DataAnalyst predefined roles

### DIFF
--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/service/RoleServiceImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/service/RoleServiceImpl.java
@@ -1,7 +1,7 @@
 package org.opendatadiscovery.oddplatform.service;
 
 import java.util.List;
-import java.util.stream.Stream;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +29,14 @@ import reactor.core.publisher.Mono;
 @Service
 @RequiredArgsConstructor
 public class RoleServiceImpl implements RoleService {
+    private static final Set<String> PREDEFINED_ROLE_NAMES = Set.of(
+        UserProviderRole.ADMIN.getValue(),
+        UserProviderRole.USER.getValue(),
+        "DataSteward",
+        "DataViewer",
+        "DataAnalyst"
+    );
+
     private final RoleMapper roleMapper;
     private final ReactiveRoleRepository roleRepository;
     private final ReactiveRoleToPolicyRepository roleToPolicyRepository;
@@ -65,8 +73,8 @@ public class RoleServiceImpl implements RoleService {
     public Mono<Role> update(final long id, final RoleFormData formData) {
         return roleRepository.get(id)
             .switchIfEmpty(Mono.error(new NotFoundException("Role", id)))
-            .filter(role -> !role.getName().equals(UserProviderRole.ADMIN.getValue()))
-            .switchIfEmpty(Mono.error(new BadUserRequestException("Administrator role is not editable")))
+            .filter(role -> !PREDEFINED_ROLE_NAMES.contains(role.getName()))
+            .switchIfEmpty(Mono.error(new BadUserRequestException("Predefined role is not editable")))
             .flatMap(role -> updateRoleName(role, formData))
             .flatMap(role -> updateRolePolicyRelations(role, formData))
             .flatMap(role -> roleRepository.getDto(role.getId()))
@@ -78,8 +86,8 @@ public class RoleServiceImpl implements RoleService {
     public Mono<Void> delete(final long id) {
         return roleRepository.get(id)
             .switchIfEmpty(Mono.error(new NotFoundException("Role", id)))
-            .filter(role -> Stream.of(UserProviderRole.values())
-                .noneMatch(r -> r.getValue().equalsIgnoreCase(role.getName())))
+            .filter(role -> PREDEFINED_ROLE_NAMES.stream()
+                .noneMatch(name -> name.equalsIgnoreCase(role.getName())))
             .switchIfEmpty(Mono.error(
                 new BadUserRequestException("Role is predefined and cannot be deleted")))
             .then(ownerToRoleRepository.isRoleAttachedToOwner(id))
@@ -101,9 +109,10 @@ public class RoleServiceImpl implements RoleService {
     }
 
     private Mono<RolePojo> updateRoleName(final RolePojo role, final RoleFormData formData) {
-        if (role.getName().equals(UserProviderRole.USER.getValue())
+        if (PREDEFINED_ROLE_NAMES.contains(role.getName())
             && !StringUtils.equals(role.getName(), formData.getName())) {
-            return Mono.error(new BadUserRequestException("User role name cannot be changed"));
+            return Mono.error(
+                new BadUserRequestException("Predefined role name cannot be changed"));
         }
         return Mono.just(roleMapper.applyToPojo(formData, role))
             .flatMap(roleRepository::update);

--- a/odd-platform-api/src/main/resources/db/migration/V0_0_102__add_extended_predefined_roles.sql
+++ b/odd-platform-api/src/main/resources/db/migration/V0_0_102__add_extended_predefined_roles.sql
@@ -1,0 +1,114 @@
+INSERT INTO policy(name, policy)
+VALUES ('DataSteward',
+        '{
+  "statements": [
+    {
+      "resource": {
+        "type": "DATA_ENTITY"
+      },
+      "permissions": [
+        "DATA_ENTITY_OWNERSHIP_CREATE",
+        "DATA_ENTITY_OWNERSHIP_UPDATE",
+        "DATA_ENTITY_OWNERSHIP_DELETE",
+        "DATA_ENTITY_TAGS_UPDATE",
+        "DATA_ENTITY_ADD_TERM",
+        "DATA_ENTITY_DELETE_TERM",
+        "DATA_ENTITY_DESCRIPTION_UPDATE",
+        "DATA_ENTITY_STATUS_UPDATE",
+        "DATA_ENTITY_CUSTOM_METADATA_CREATE",
+        "DATA_ENTITY_CUSTOM_METADATA_UPDATE",
+        "DATA_ENTITY_CUSTOM_METADATA_DELETE",
+        "DATA_ENTITY_INTERNAL_NAME_UPDATE",
+        "DATA_ENTITY_ATTACHMENT_MANAGE"
+      ]
+    },
+    {
+      "resource": {
+        "type": "TERM"
+      },
+      "permissions": [
+        "TERM_TAGS_UPDATE",
+        "TERM_UPDATE"
+      ]
+    }
+  ]
+}')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO policy(name, policy)
+VALUES ('DataViewer',
+        '{
+  "statements": [
+    {
+      "resource": {
+        "type": "DATA_ENTITY"
+      },
+      "permissions": []
+    },
+    {
+      "resource": {
+        "type": "TERM"
+      },
+      "permissions": []
+    }
+  ]
+}')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO policy(name, policy)
+VALUES ('DataAnalyst',
+        '{
+  "statements": [
+    {
+      "resource": {
+        "type": "DATA_ENTITY"
+      },
+      "permissions": [
+        "DATA_ENTITY_CUSTOM_METADATA_CREATE",
+        "DATA_ENTITY_CUSTOM_METADATA_UPDATE",
+        "DATA_ENTITY_CUSTOM_METADATA_DELETE",
+        "DATA_ENTITY_TAGS_UPDATE",
+        "DATA_ENTITY_DESCRIPTION_UPDATE",
+        "DATA_ENTITY_INTERNAL_NAME_UPDATE",
+        "QUERY_EXAMPLE_DATASET_CREATE",
+        "QUERY_EXAMPLE_DATASET_DELETE",
+        "DATASET_FIELD_DESCRIPTION_UPDATE",
+        "DATASET_FIELD_INTERNAL_NAME_UPDATE",
+        "DATASET_FIELD_TAGS_UPDATE",
+        "DATASET_FIELD_ENUMS_UPDATE",
+        "DATASET_FIELD_ADD_TERM",
+        "DATASET_FIELD_DELETE_TERM"
+      ]
+    },
+    {
+      "resource": {
+        "type": "TERM"
+      },
+      "permissions": [
+        "TERM_TAGS_UPDATE"
+      ]
+    }
+  ]
+}')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO role(name)
+VALUES ('DataSteward'),
+       ('DataViewer'),
+       ('DataAnalyst')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO role_to_policy(role_id, policy_id)
+VALUES ((SELECT id FROM role WHERE name = 'DataSteward' AND deleted_at IS NULL),
+        (SELECT id FROM policy WHERE name = 'DataSteward' AND deleted_at IS NULL))
+ON CONFLICT DO NOTHING;
+
+INSERT INTO role_to_policy(role_id, policy_id)
+VALUES ((SELECT id FROM role WHERE name = 'DataViewer' AND deleted_at IS NULL),
+        (SELECT id FROM policy WHERE name = 'DataViewer' AND deleted_at IS NULL))
+ON CONFLICT DO NOTHING;
+
+INSERT INTO role_to_policy(role_id, policy_id)
+VALUES ((SELECT id FROM role WHERE name = 'DataAnalyst' AND deleted_at IS NULL),
+        (SELECT id FROM policy WHERE name = 'DataAnalyst' AND deleted_at IS NULL))
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## What

Add three predefined RBAC roles to cover common enterprise data governance scenarios:

| Role | Scope | Key Permissions |
|------|-------|----------------|
| **DataSteward** | Data governance | Ownership CRUD, tags, terms, descriptions, status, custom metadata, attachments |
| **DataViewer** | Read-only access | No write permissions -- explicitly empty permission blocks for DATA_ENTITY + TERM |
| **DataAnalyst** | Metadata enrichment | Custom metadata, tags, descriptions, query examples, dataset field metadata |

Also refactors `RoleServiceImpl` to use a single `PREDEFINED_ROLE_NAMES` set treated consistently across `update()`, `delete()`, and `updateRoleName()` -- previously these three methods checked different role-name sources (`UserProviderRole.ADMIN` vs `UserProviderRole.USER` vs `Stream.of(UserProviderRole.values())`).

## Why

The platform ships with only two predefined roles (Administrator / User). This forces teams to either grant too much access or too little, making least-privilege impossible without manually crafting custom roles for every deployment.

These three roles mirror real-world data team structures: stewards govern data, analysts enrich it, and viewers consume it.

## How

1. **Flyway migration** `V0_0_102`: inserts 3 policies + 3 roles + 3 `role_to_policy` relations, all with `ON CONFLICT DO NOTHING`
2. **RoleServiceImpl**: replace scattered role-name guard checks with a single `PREDEFINED_ROLE_NAMES` set
3. All three new roles are immutable -- cannot be deleted or renamed

## Checklist

- [x] No changes to policy JSON schema or permission enum required
- [x] Existing Administrator/User roles unaffected
- [x] Flyway migration is idempotent (`ON CONFLICT DO NOTHING`)
- [x] Follows existing `V0_0_56` pattern
