### PR TITLE
fix(terms): linked-terms count excludes soft-deleted terms

### DIFF
--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveTermRepositoryImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveTermRepositoryImpl.java
@@ -196,6 +196,7 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
         final Table<NamespaceRecord> assignedTermsNamespace = NAMESPACE.asTable("assigned_terms_namespace");
         final Table<TermToTermRecord> assignedTermRelations = TERM_TO_TERM.asTable("assigned_term_relations");
         final Table<TermToTermRecord> linkedTerms = TERM_TO_TERM.asTable("linked_terms");
+        final Table<TermRecord> linkedTermsTerm = TERM.asTable("linked_terms_term");
 
         final List<Field<?>> groupByFields = Stream.of(TERM.fields(), NAMESPACE.fields())
             .flatMap(Arrays::stream)
@@ -213,7 +214,9 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .select(DSL.countDistinct(DATA_ENTITY_TO_TERM.DATA_ENTITY_ID).as(ENTITIES_COUNT))
             .select(DSL.countDistinct(DATASET_FIELD_TO_TERM.DATASET_FIELD_ID).as(COLUMNS_COUNT))
             .select(DSL.countDistinct(QUERY_EXAMPLE_TO_TERM.QUERY_EXAMPLE_ID).as(QUERY_EXAMPLE_COUNT))
-            .select(DSL.countDistinct(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID)).as(LINKED_TERMS_COUNT))
+            .select(DSL.countDistinct(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID))
+                .filterWhere(linkedTermsTerm.field(TERM.DELETED_AT).isNull())
+                .as(LINKED_TERMS_COUNT))
             .from(TERM)
             .join(NAMESPACE).on(NAMESPACE.ID.eq(TERM.NAMESPACE_ID))
             .leftJoin(TERM_OWNERSHIP).on(TERM_OWNERSHIP.TERM_ID.eq(TERM.ID))
@@ -225,6 +228,8 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .leftJoin(DATASET_FIELD_TO_TERM).on(DATASET_FIELD_TO_TERM.TERM_ID.eq(TERM.ID))
             .leftJoin(QUERY_EXAMPLE_TO_TERM).on(QUERY_EXAMPLE_TO_TERM.TERM_ID.eq(TERM.ID))
             .leftJoin(linkedTerms).on(linkedTerms.field(TERM_TO_TERM.ASSIGNED_TERM_ID).eq(TERM.ID))
+            .leftJoin(linkedTermsTerm)
+            .on(linkedTermsTerm.field(TERM.ID).eq(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID)))
             .leftJoin(assignedTermRelations)
             .on(assignedTermRelations.field(TERM_TO_TERM.TARGET_TERM_ID).eq(TERM.ID))
             .leftJoin(assignedTerms)
@@ -322,6 +327,7 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .toList();
 
         final Table<TermToTermRecord> linkedTerms = TERM_TO_TERM.asTable("linked_terms");
+        final Table<TermRecord> linkedTermsTerm = TERM.asTable("linked_terms_term");
 
         final var query = DSL.with(termCTE.getName())
             .as(termSelect)
@@ -333,7 +339,9 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .select(DSL.countDistinct(DATA_ENTITY_TO_TERM.DATA_ENTITY_ID).as(ENTITIES_COUNT))
             .select(DSL.countDistinct(DATASET_FIELD_TO_TERM.DATASET_FIELD_ID).as(COLUMNS_COUNT))
             .select(DSL.countDistinct(QUERY_EXAMPLE_TO_TERM.QUERY_EXAMPLE_ID).as(QUERY_EXAMPLE_COUNT))
-            .select(DSL.countDistinct(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID)).as(LINKED_TERMS_COUNT))
+            .select(DSL.countDistinct(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID))
+                .filterWhere(linkedTermsTerm.field(TERM.DELETED_AT).isNull())
+                .as(LINKED_TERMS_COUNT))
             .from(termCTE.getName())
             .join(NAMESPACE).on(NAMESPACE.ID.eq(termCTE.field(TERM.NAMESPACE_ID)))
             .leftJoin(TERM_OWNERSHIP).on(TERM_OWNERSHIP.TERM_ID.eq(termCTE.field(TERM.ID)))
@@ -343,6 +351,8 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .leftJoin(DATASET_FIELD_TO_TERM).on(DATASET_FIELD_TO_TERM.TERM_ID.eq(termCTE.field(TERM.ID)))
             .leftJoin(QUERY_EXAMPLE_TO_TERM).on(QUERY_EXAMPLE_TO_TERM.TERM_ID.eq(termCTE.field(TERM.ID)))
             .leftJoin(linkedTerms).on(linkedTerms.field(TERM_TO_TERM.ASSIGNED_TERM_ID).eq(termCTE.field(TERM.ID)))
+            .leftJoin(linkedTermsTerm)
+            .on(linkedTermsTerm.field(TERM.ID).eq(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID)))
             .groupBy(groupByFields);
 
         return jooqReactiveOperations.flux(query)

--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/repository/TermRepositoryTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/repository/TermRepositoryTest.java
@@ -1,0 +1,70 @@
+package org.opendatadiscovery.oddplatform.repository;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.opendatadiscovery.oddplatform.BaseIntegrationTest;
+import org.opendatadiscovery.oddplatform.model.tables.pojos.NamespacePojo;
+import org.opendatadiscovery.oddplatform.model.tables.pojos.TermPojo;
+import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveNamespaceRepository;
+import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveTermRepository;
+import org.opendatadiscovery.oddplatform.repository.reactive.TermRelationsRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TermRepositoryTest extends BaseIntegrationTest {
+
+    @Autowired
+    private ReactiveTermRepository termRepository;
+    @Autowired
+    private TermRelationsRepository termRelationsRepository;
+    @Autowired
+    private ReactiveNamespaceRepository namespaceRepository;
+
+    @Test
+    @DisplayName("linkedTermsUsingCount excludes soft-deleted linked terms and matches the linked-terms list")
+    void linkedTermsCountMatchesListAndExcludesDeleted() {
+        final NamespacePojo namespace = namespaceRepository.createByName(unique("namespace")).block();
+
+        final TermPojo viewedTerm = createTerm(namespace.getId());
+        final TermPojo linked1 = createTerm(namespace.getId());
+        final TermPojo linked2 = createTerm(namespace.getId());
+
+        // Both relations are stored with the viewed term as ASSIGNED, so they surface in the
+        // viewed term's linked-terms list and count (target = linked term).
+        termRelationsRepository.createRelationWithTerm(viewedTerm.getId(), linked1.getId()).block();
+        termRelationsRepository.createRelationWithTerm(viewedTerm.getId(), linked2.getId()).block();
+
+        // Before deletion: both the aggregate count and the list see 2 linked terms.
+        assertThat(linkedTermsCount(viewedTerm.getId())).isEqualTo(2);
+        assertThat(linkedTermsListSize(viewedTerm.getId())).isEqualTo(2);
+
+        // Soft-delete one linked term.
+        termRepository.delete(linked2.getId()).block();
+
+        // After deletion: the list drops it (DELETED_AT filter) and the count must follow.
+        assertThat(linkedTermsListSize(viewedTerm.getId())).isEqualTo(1);
+        assertThat(linkedTermsCount(viewedTerm.getId())).isEqualTo(1);
+    }
+
+    private int linkedTermsCount(final Long termId) {
+        return termRepository.getTermDetailsDto(termId).block()
+            .getTermDto().getLinkedTermsUsingCount();
+    }
+
+    private long linkedTermsListSize(final Long termId) {
+        return termRepository.listByTerm(termId, null, 1, 30).count().block();
+    }
+
+    private TermPojo createTerm(final Long namespaceId) {
+        return termRepository.create(new TermPojo()
+            .setName(unique("term"))
+            .setDefinition("definition")
+            .setNamespaceId(namespaceId)).block();
+    }
+
+    private static String unique(final String prefix) {
+        return prefix + "_" + UUID.randomUUID();
+    }
+}

--- a/odd-platform-ui/src/components/Terms/TermDetails/TermDetailsTabs/TermDetailsTabs.tsx
+++ b/odd-platform-ui/src/components/Terms/TermDetails/TermDetailsTabs/TermDetailsTabs.tsx
@@ -37,7 +37,14 @@ const TermDetailsTabs: React.FC = () => {
         link: termDetailsPath(termId, 'query-examples'),
       },
     ],
-    [termId, termDetails?.entitiesUsingCount, termDetails?.columnsUsingCount, t]
+    [
+      termId,
+      termDetails?.entitiesUsingCount,
+      termDetails?.columnsUsingCount,
+      termDetails?.linkedTermsUsingCount,
+      termDetails?.queryExampleUsingCount,
+      t,
+    ]
   );
 
   const selectedTab = useSetSelectedTab(tabs);


### PR DESCRIPTION
## Problem
The Term detail page's **Linked terms** tab badge counted soft-deleted linked terms, so the count didn't match the actual list (the list already filters `DELETED_AT`).

## Fix
- **`ReactiveTermRepositoryImpl`**: in both `getTermDetailsDto` and `listByTerm` count paths, join `TERM` via a `linked_terms_term` alias and add `.filterWhere(DELETED_AT is null)` on `LINKED_TERMS_COUNT` so the count follows the list.
- **`TermDetailsTabs.tsx`**: add missing `useMemo` deps (`linkedTermsUsingCount`, `queryExampleUsingCount`) so the hint badge re-renders when the corrected count arrives.
- **`TermRepositoryTest`** (new): integration test asserting count == list (2/2), then soft-delete one linked term → (1/1).

## Testing
`./gradlew odd-platform-api:test --tests '*TermRepositoryTest*'` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)