### PR TITLE
fix(terms): correct linked-terms count + make manual term-to-term links bi-directional

### DIFF
--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveTermRepositoryImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveTermRepositoryImpl.java
@@ -194,8 +194,10 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
     public Mono<TermDetailsDto> getTermDetailsDto(final Long id) {
         final Table<TermRecord> assignedTerms = TERM.asTable("assigned_terms");
         final Table<NamespaceRecord> assignedTermsNamespace = NAMESPACE.asTable("assigned_terms_namespace");
-        final Table<TermToTermRecord> assignedTermRelations = TERM_TO_TERM.asTable("assigned_term_relations");
-        final Table<TermToTermRecord> linkedTerms = TERM_TO_TERM.asTable("linked_terms");
+        // Manual term-to-term links are undirected: the augmented relation exposes each manual
+        // edge in both orientations so a link is visible/removable from either term's page.
+        final Table<? extends Record> assignedTermRelations = symmetricTermRelations("assigned_term_relations");
+        final Table<? extends Record> linkedTerms = symmetricTermRelations("linked_terms");
         final Table<TermRecord> linkedTermsTerm = TERM.asTable("linked_terms_term");
 
         final List<Field<?>> groupByFields = Stream.of(TERM.fields(), NAMESPACE.fields())
@@ -233,7 +235,8 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .leftJoin(assignedTermRelations)
             .on(assignedTermRelations.field(TERM_TO_TERM.TARGET_TERM_ID).eq(TERM.ID))
             .leftJoin(assignedTerms)
-            .on(assignedTerms.field(TERM.ID).eq(assignedTermRelations.field(TERM_TO_TERM.ASSIGNED_TERM_ID)))
+            .on(assignedTerms.field(TERM.ID).eq(assignedTermRelations.field(TERM_TO_TERM.ASSIGNED_TERM_ID))
+                .and(assignedTerms.field(TERM.DELETED_AT).isNull()))
             .leftJoin(assignedTermsNamespace)
             .on(assignedTerms.field(TERM.NAMESPACE_ID).eq(assignedTermsNamespace.field(NAMESPACE.ID)))
             .where(TERM.ID.eq(id).and(TERM.DELETED_AT.isNull()))
@@ -326,7 +329,7 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .flatMap(Arrays::stream)
             .toList();
 
-        final Table<TermToTermRecord> linkedTerms = TERM_TO_TERM.asTable("linked_terms");
+        final Table<? extends Record> linkedTerms = symmetricTermRelations("linked_terms");
         final Table<TermRecord> linkedTermsTerm = TERM.asTable("linked_terms_term");
 
         final var query = DSL.with(termCTE.getName())
@@ -480,7 +483,7 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .orderBy(TERM.ID.desc());
 
         final Table<Record> termCTE = baseQuery.asTable("term_cte");
-        final Table<TermToTermRecord> assignedTermRelations = TERM_TO_TERM.asTable("assigned_term_relations");
+        final Table<? extends Record> assignedTermRelations = symmetricTermRelations("assigned_term_relations");
 
         final List<Field<?>> groupByFields = Stream.of(termCTE.fields(), NAMESPACE.fields(),
                 assignedTermRelations.fields(TERM_TO_TERM.IS_DESCRIPTION_LINK))
@@ -534,6 +537,22 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
 
         return jooqReactiveOperations.mono(finalQuery)
             .map(this::mapRecordToLinkedTermDto);
+    }
+
+    // A manual (non-description) term-to-term link has no inherent direction, yet it is stored as a
+    // single directed row (assigned -> target). This derived table keeps every row as-is and adds a
+    // mirrored copy of each manual row with the endpoints swapped, so callers can keep their existing
+    // join direction while seeing manual links from both sides. Description links (is_description_link
+    // = true) are NOT mirrored: they stay directional ("references" vs "referenced-by").
+    private Table<? extends Record> symmetricTermRelations(final String alias) {
+        return DSL
+            .select(TERM_TO_TERM.ASSIGNED_TERM_ID, TERM_TO_TERM.TARGET_TERM_ID, TERM_TO_TERM.IS_DESCRIPTION_LINK)
+            .from(TERM_TO_TERM)
+            .unionAll(DSL
+                .select(TERM_TO_TERM.TARGET_TERM_ID, TERM_TO_TERM.ASSIGNED_TERM_ID, TERM_TO_TERM.IS_DESCRIPTION_LINK)
+                .from(TERM_TO_TERM)
+                .where(TERM_TO_TERM.IS_DESCRIPTION_LINK.isFalse()))
+            .asTable(alias);
     }
 
     private LinkedTermDto mapRecordToLinkedTermDto(final Record record) {

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveTermRepositoryImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveTermRepositoryImpl.java
@@ -196,6 +196,7 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
         final Table<NamespaceRecord> assignedTermsNamespace = NAMESPACE.asTable("assigned_terms_namespace");
         final Table<TermToTermRecord> assignedTermRelations = TERM_TO_TERM.asTable("assigned_term_relations");
         final Table<TermToTermRecord> linkedTerms = TERM_TO_TERM.asTable("linked_terms");
+        final Table<TermRecord> linkedTermsTerm = TERM.asTable("linked_terms_term");
 
         final List<Field<?>> groupByFields = Stream.of(TERM.fields(), NAMESPACE.fields())
             .flatMap(Arrays::stream)
@@ -213,7 +214,9 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .select(DSL.countDistinct(DATA_ENTITY_TO_TERM.DATA_ENTITY_ID).as(ENTITIES_COUNT))
             .select(DSL.countDistinct(DATASET_FIELD_TO_TERM.DATASET_FIELD_ID).as(COLUMNS_COUNT))
             .select(DSL.countDistinct(QUERY_EXAMPLE_TO_TERM.QUERY_EXAMPLE_ID).as(QUERY_EXAMPLE_COUNT))
-            .select(DSL.countDistinct(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID)).as(LINKED_TERMS_COUNT))
+            .select(DSL.countDistinct(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID))
+                .filterWhere(linkedTermsTerm.field(TERM.DELETED_AT).isNull())
+                .as(LINKED_TERMS_COUNT))
             .from(TERM)
             .join(NAMESPACE).on(NAMESPACE.ID.eq(TERM.NAMESPACE_ID))
             .leftJoin(TERM_OWNERSHIP).on(TERM_OWNERSHIP.TERM_ID.eq(TERM.ID))
@@ -225,6 +228,8 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .leftJoin(DATASET_FIELD_TO_TERM).on(DATASET_FIELD_TO_TERM.TERM_ID.eq(TERM.ID))
             .leftJoin(QUERY_EXAMPLE_TO_TERM).on(QUERY_EXAMPLE_TO_TERM.TERM_ID.eq(TERM.ID))
             .leftJoin(linkedTerms).on(linkedTerms.field(TERM_TO_TERM.ASSIGNED_TERM_ID).eq(TERM.ID))
+            .leftJoin(linkedTermsTerm)
+            .on(linkedTermsTerm.field(TERM.ID).eq(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID)))
             .leftJoin(assignedTermRelations)
             .on(assignedTermRelations.field(TERM_TO_TERM.TARGET_TERM_ID).eq(TERM.ID))
             .leftJoin(assignedTerms)
@@ -322,6 +327,7 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .toList();
 
         final Table<TermToTermRecord> linkedTerms = TERM_TO_TERM.asTable("linked_terms");
+        final Table<TermRecord> linkedTermsTerm = TERM.asTable("linked_terms_term");
 
         final var query = DSL.with(termCTE.getName())
             .as(termSelect)
@@ -333,7 +339,9 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .select(DSL.countDistinct(DATA_ENTITY_TO_TERM.DATA_ENTITY_ID).as(ENTITIES_COUNT))
             .select(DSL.countDistinct(DATASET_FIELD_TO_TERM.DATASET_FIELD_ID).as(COLUMNS_COUNT))
             .select(DSL.countDistinct(QUERY_EXAMPLE_TO_TERM.QUERY_EXAMPLE_ID).as(QUERY_EXAMPLE_COUNT))
-            .select(DSL.countDistinct(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID)).as(LINKED_TERMS_COUNT))
+            .select(DSL.countDistinct(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID))
+                .filterWhere(linkedTermsTerm.field(TERM.DELETED_AT).isNull())
+                .as(LINKED_TERMS_COUNT))
             .from(termCTE.getName())
             .join(NAMESPACE).on(NAMESPACE.ID.eq(termCTE.field(TERM.NAMESPACE_ID)))
             .leftJoin(TERM_OWNERSHIP).on(TERM_OWNERSHIP.TERM_ID.eq(termCTE.field(TERM.ID)))
@@ -343,6 +351,8 @@ public class ReactiveTermRepositoryImpl extends ReactiveAbstractSoftDeleteCRUDRe
             .leftJoin(DATASET_FIELD_TO_TERM).on(DATASET_FIELD_TO_TERM.TERM_ID.eq(termCTE.field(TERM.ID)))
             .leftJoin(QUERY_EXAMPLE_TO_TERM).on(QUERY_EXAMPLE_TO_TERM.TERM_ID.eq(termCTE.field(TERM.ID)))
             .leftJoin(linkedTerms).on(linkedTerms.field(TERM_TO_TERM.ASSIGNED_TERM_ID).eq(termCTE.field(TERM.ID)))
+            .leftJoin(linkedTermsTerm)
+            .on(linkedTermsTerm.field(TERM.ID).eq(linkedTerms.field(TERM_TO_TERM.TARGET_TERM_ID)))
             .groupBy(groupByFields);
 
         return jooqReactiveOperations.flux(query)

--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/TermRelationsRepositoryImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/TermRelationsRepositoryImpl.java
@@ -220,10 +220,12 @@ public class TermRelationsRepositoryImpl implements TermRelationsRepository {
 
     @Override
     public Mono<TermToTermPojo> deleteTermToLinkedTermRelation(final Long linkedTermId, final Long termId) {
+        // A manual link is undirected and may be stored in either orientation (and, if linked from
+        // both pages, in both). Remove it regardless of which side is assigned/target.
         final var query = DSL.deleteFrom(TERM_TO_TERM)
-            .where(TERM_TO_TERM.ASSIGNED_TERM_ID.eq(linkedTermId)
-                .and(TERM_TO_TERM.TARGET_TERM_ID.eq(termId))
-                .and(TERM_TO_TERM.IS_DESCRIPTION_LINK.isFalse()))
+            .where(TERM_TO_TERM.IS_DESCRIPTION_LINK.isFalse()
+                .and(TERM_TO_TERM.ASSIGNED_TERM_ID.eq(linkedTermId).and(TERM_TO_TERM.TARGET_TERM_ID.eq(termId))
+                    .or(TERM_TO_TERM.ASSIGNED_TERM_ID.eq(termId).and(TERM_TO_TERM.TARGET_TERM_ID.eq(linkedTermId)))))
             .returning();
         return jooqReactiveOperations.mono(query)
             .map(r -> r.into(TermToTermPojo.class));

--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/repository/TermRepositoryTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/repository/TermRepositoryTest.java
@@ -1,0 +1,70 @@
+package org.opendatadiscovery.oddplatform.repository;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.opendatadiscovery.oddplatform.BaseIntegrationTest;
+import org.opendatadiscovery.oddplatform.model.tables.pojos.NamespacePojo;
+import org.opendatadiscovery.oddplatform.model.tables.pojos.TermPojo;
+import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveNamespaceRepository;
+import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveTermRepository;
+import org.opendatadiscovery.oddplatform.repository.reactive.TermRelationsRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TermRepositoryTest extends BaseIntegrationTest {
+
+    @Autowired
+    private ReactiveTermRepository termRepository;
+    @Autowired
+    private TermRelationsRepository termRelationsRepository;
+    @Autowired
+    private ReactiveNamespaceRepository namespaceRepository;
+
+    @Test
+    @DisplayName("linkedTermsUsingCount excludes soft-deleted linked terms and matches the linked-terms list")
+    void linkedTermsCountMatchesListAndExcludesDeleted() {
+        final NamespacePojo namespace = namespaceRepository.createByName(unique("namespace")).block();
+
+        final TermPojo viewedTerm = createTerm(namespace.getId());
+        final TermPojo linked1 = createTerm(namespace.getId());
+        final TermPojo linked2 = createTerm(namespace.getId());
+
+        // Both relations are stored with the viewed term as ASSIGNED, so they surface in the
+        // viewed term's linked-terms list and count (target = linked term).
+        termRelationsRepository.createRelationWithTerm(viewedTerm.getId(), linked1.getId()).block();
+        termRelationsRepository.createRelationWithTerm(viewedTerm.getId(), linked2.getId()).block();
+
+        // Before deletion: both the aggregate count and the list see 2 linked terms.
+        assertThat(linkedTermsCount(viewedTerm.getId())).isEqualTo(2);
+        assertThat(linkedTermsListSize(viewedTerm.getId())).isEqualTo(2);
+
+        // Soft-delete one linked term.
+        termRepository.delete(linked2.getId()).block();
+
+        // After deletion: the list drops it (DELETED_AT filter) and the count must follow.
+        assertThat(linkedTermsListSize(viewedTerm.getId())).isEqualTo(1);
+        assertThat(linkedTermsCount(viewedTerm.getId())).isEqualTo(1);
+    }
+
+    private int linkedTermsCount(final Long termId) {
+        return termRepository.getTermDetailsDto(termId).block()
+            .getTermDto().getLinkedTermsUsingCount();
+    }
+
+    private long linkedTermsListSize(final Long termId) {
+        return termRepository.listByTerm(termId, null, 1, 30).count().block();
+    }
+
+    private TermPojo createTerm(final Long namespaceId) {
+        return termRepository.create(new TermPojo()
+            .setName(unique("term"))
+            .setDefinition("definition")
+            .setNamespaceId(namespaceId)).block();
+    }
+
+    private static String unique(final String prefix) {
+        return prefix + "_" + UUID.randomUUID();
+    }
+}

--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/repository/TermRepositoryTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/repository/TermRepositoryTest.java
@@ -1,11 +1,16 @@
 package org.opendatadiscovery.oddplatform.repository;
 
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.opendatadiscovery.oddplatform.BaseIntegrationTest;
+import org.opendatadiscovery.oddplatform.dto.term.LinkedTermDto;
 import org.opendatadiscovery.oddplatform.model.tables.pojos.NamespacePojo;
 import org.opendatadiscovery.oddplatform.model.tables.pojos.TermPojo;
+import org.opendatadiscovery.oddplatform.model.tables.pojos.TermToTermPojo;
 import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveNamespaceRepository;
 import org.opendatadiscovery.oddplatform.repository.reactive.ReactiveTermRepository;
 import org.opendatadiscovery.oddplatform.repository.reactive.TermRelationsRepository;
@@ -46,6 +51,92 @@ public class TermRepositoryTest extends BaseIntegrationTest {
         // After deletion: the list drops it (DELETED_AT filter) and the count must follow.
         assertThat(linkedTermsListSize(viewedTerm.getId())).isEqualTo(1);
         assertThat(linkedTermsCount(viewedTerm.getId())).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("a manual link is symmetric: visible in Overview, list and count on BOTH terms")
+    void manualLinkIsBidirectional() {
+        final NamespacePojo namespace = namespaceRepository.createByName(unique("namespace")).block();
+        final TermPojo pageTerm = createTerm(namespace.getId());
+        final TermPojo picked = createTerm(namespace.getId());
+
+        // On pageTerm's page, add `picked` — stored once as (assigned=picked, target=pageTerm).
+        linkFromPage(pageTerm.getId(), picked.getId());
+
+        // Overview TERMS panel of each term shows the other.
+        assertThat(overviewTermIds(pageTerm.getId())).contains(picked.getId());
+        assertThat(overviewTermIds(picked.getId())).contains(pageTerm.getId());
+
+        // "Linked terms" tab list + badge count agree and see the link from both sides.
+        assertThat(tabTermIds(pageTerm.getId())).containsExactly(picked.getId());
+        assertThat(tabTermIds(picked.getId())).containsExactly(pageTerm.getId());
+        assertThat(linkedTermsCount(pageTerm.getId())).isEqualTo(1);
+        assertThat(linkedTermsCount(picked.getId())).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("a manual link can be removed from either term's side")
+    void manualLinkRemovableFromEitherSide() {
+        final NamespacePojo namespace = namespaceRepository.createByName(unique("namespace")).block();
+        final TermPojo pageTerm = createTerm(namespace.getId());
+        final TermPojo picked = createTerm(namespace.getId());
+
+        // Stored as (assigned=picked, target=pageTerm).
+        linkFromPage(pageTerm.getId(), picked.getId());
+
+        // Remove from the OTHER side (picked's page) — reversed orientation vs how it was stored.
+        // Mirrors controller: deleteLinkedTermFromTerm(termId=picked, linkedTermId=pageTerm).
+        termRelationsRepository.deleteTermToLinkedTermRelation(pageTerm.getId(), picked.getId()).block();
+
+        assertThat(linkedTermsCount(pageTerm.getId())).isZero();
+        assertThat(linkedTermsCount(picked.getId())).isZero();
+        assertThat(overviewTermIds(pageTerm.getId())).doesNotContain(picked.getId());
+        assertThat(overviewTermIds(picked.getId())).doesNotContain(pageTerm.getId());
+    }
+
+    @Test
+    @DisplayName("description links stay directional: Overview shows 'references', tab shows 'referenced-by'")
+    void descriptionLinkStaysDirectional() {
+        final NamespacePojo namespace = namespaceRepository.createByName(unique("namespace")).block();
+        final TermPojo term = createTerm(namespace.getId());
+        final TermPojo mentioned = createTerm(namespace.getId());
+
+        // `term`'s definition mentions `mentioned` -> (assigned=mentioned, target=term, description=true).
+        termRelationsRepository.createRelationsWithTerm(List.of(new TermToTermPojo()
+            .setAssignedTermId(mentioned.getId())
+            .setTargetTermId(term.getId())
+            .setIsDescriptionLink(true))).collectList().block();
+
+        // Overview of `term` shows `mentioned` (term references it), flagged as a description link.
+        final LinkedTermDto overviewEntry = termRepository.getTermDetailsDto(term.getId()).block()
+            .getTerms().stream()
+            .filter(dto -> dto.term().getTerm().getId().equals(mentioned.getId()))
+            .findFirst().orElseThrow();
+        assertThat(overviewEntry.isDescriptionLink()).isTrue();
+
+        // Not mirrored: `mentioned`'s Overview must NOT list `term`, and `term`'s tab must NOT list it.
+        assertThat(overviewTermIds(mentioned.getId())).doesNotContain(term.getId());
+        assertThat(tabTermIds(term.getId())).doesNotContain(mentioned.getId());
+
+        // The tab keeps the back-reference: `mentioned`'s tab shows `term` (referenced-by).
+        assertThat(tabTermIds(mentioned.getId())).contains(term.getId());
+    }
+
+    // Mirrors the controller add-link flow: on `pageTermId`'s page, pick `pickedTermId`.
+    private void linkFromPage(final Long pageTermId, final Long pickedTermId) {
+        termRelationsRepository.createRelationWithTerm(pickedTermId, pageTermId).block();
+    }
+
+    private Set<Long> overviewTermIds(final Long termId) {
+        return termRepository.getTermDetailsDto(termId).block().getTerms().stream()
+            .map(dto -> dto.term().getTerm().getId())
+            .collect(Collectors.toSet());
+    }
+
+    private Set<Long> tabTermIds(final Long termId) {
+        return termRepository.listByTerm(termId, null, 1, 30)
+            .map(dto -> dto.term().getTerm().getId())
+            .collect(Collectors.toSet()).block();
     }
 
     private int linkedTermsCount(final Long termId) {

--- a/odd-platform-ui/src/components/Terms/TermDetails/TermDetailsTabs/TermDetailsTabs.tsx
+++ b/odd-platform-ui/src/components/Terms/TermDetails/TermDetailsTabs/TermDetailsTabs.tsx
@@ -37,7 +37,14 @@ const TermDetailsTabs: React.FC = () => {
         link: termDetailsPath(termId, 'query-examples'),
       },
     ],
-    [termId, termDetails?.entitiesUsingCount, termDetails?.columnsUsingCount, t]
+    [
+      termId,
+      termDetails?.entitiesUsingCount,
+      termDetails?.columnsUsingCount,
+      termDetails?.linkedTermsUsingCount,
+      termDetails?.queryExampleUsingCount,
+      t,
+    ]
   );
 
   const selectedTab = useSetSelectedTab(tabs);


### PR DESCRIPTION
Supersedes #1863 (includes its commit).

Two related fixes to term-to-term linking.

## 1. Linked-terms count excluded soft-deleted terms
The "Linked terms" tab badge counted soft-deleted linked terms, so it didn't match the list (which already filters `DELETED_AT`). The `LINKED_TERMS_COUNT` aggregate now filters out soft-deleted linked terms; `TermDetailsTabs.tsx` gets the missing `useMemo` deps so the badge re-renders.

## 2. Manual term-to-term links were not bi-directional
Per the docs, an Overview → TERMS link "is bi-directionally visible: it appears on both terms' pages and can be removed from either side." It wasn't.

**Root cause:** a manual link is stored as one directed row (`assigned → target`), but the two read surfaces read opposite directions — the Overview TERMS panel (`getTermDetailsDto`) reads `target = X`, while the "Linked terms" tab + badge (`listByTerm` / count) read `assigned = X`. So one edge showed only in one term's Overview (removable there) and the other term's read-only tab.

**Fix:**
- New `symmetricTermRelations()` derived table = all `term_to_term` rows + a mirrored copy of each **manual** row (endpoints swapped; description-links excluded so they stay directional — Overview = "references", tab = "referenced-by"). Swapped in for the `term_to_term` aliases in `getTermDetailsDto`, `findByState`, `listByTerm`; each keeps its existing join direction but now sees manual links from both sides.
- `deleteTermToLinkedTermRelation` removes a manual edge in either orientation.
- Overview list also excludes soft-deleted terms (consistency with tab/count).

No API-contract change. Frontend already re-fetches term details after add/remove.

## Testing
`./gradlew odd-platform-api:test --tests '*TermRepositoryTest*'` — passes (count/soft-delete, bidirectional symmetry, remove-from-either-side, description-link-stays-directional). Checkstyle green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)