### PR TITLE
fix: Call of external resource https://ditro.io/policy.json leads to warnings

### DIFF
--- a/odd-platform-api/src/main/resources/schema/policy_schema.json
+++ b/odd-platform-api/src/main/resources/schema/policy_schema.json
@@ -76,6 +76,7 @@
           "then": {
             "properties": {
               "permissions": {
+                "type": "array",
                 "items": {
                   "anyOf": [
                     {
@@ -113,6 +114,7 @@
           "then": {
             "properties": {
               "permissions": {
+                "type": "array",
                 "items": {
                   "anyOf": [
                     {
@@ -149,6 +151,7 @@
           "then": {
             "properties": {
               "permissions": {
+                "type": "array",
                 "items": {
                   "anyOf": [
                     {
@@ -186,6 +189,7 @@
           "then": {
             "properties": {
               "permissions": {
+                "type": "array",
                 "items": {
                   "anyOf": [
                     {

--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/json/JsonSchemaTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/json/JsonSchemaTest.java
@@ -7,7 +7,10 @@ import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -56,5 +59,28 @@ public class JsonSchemaTest {
             JsonSchemaTest.class.getResourceAsStream(policyPath));
         final Set<ValidationMessage> errors = jsonSchema.validate(jsonNode);
         assertThat(errors).isNotEmpty();
+    }
+
+    @Test
+    public void testEveryItemsKeywordDeclaresArrayType() throws IOException {
+        final JsonNode schema = mapper.readTree(
+            JsonSchemaTest.class.getResourceAsStream("/schema/policy_schema.json"));
+        final List<String> pathsWithoutArrayType = new ArrayList<>();
+        collectItemsPathsWithoutArrayType(schema, "#", pathsWithoutArrayType);
+        assertThat(pathsWithoutArrayType).isEmpty();
+    }
+
+    private void collectItemsPathsWithoutArrayType(final JsonNode node, final String path, final List<String> acc) {
+        if (node.isObject()) {
+            if (node.has("items") && !"array".equals(node.path("type").asText())) {
+                acc.add(path);
+            }
+            node.fields().forEachRemaining(
+                field -> collectItemsPathsWithoutArrayType(field.getValue(), path + "/" + field.getKey(), acc));
+        } else if (node.isArray()) {
+            for (int i = 0; i < node.size(); i++) {
+                collectItemsPathsWithoutArrayType(node.get(i), path + "/" + i, acc);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1144

## Root cause

Policy JSON schema uses `items` without `"type": "array"` in conditional `then` branches

## Changes

- Added the missing `"type": "array"` next to `items` in all four conditional `then.properties.permissions` subschemas of `policy_schema.json`, which is what Ajv's `strictTypes` check requires. Also added a regression test asserting every subschema that uses `items` declares `"type": "array"`.