### PR TITLE
fix: metric family re-ingestion 500s once a description is stored (RETURNING skipped by DO UPDATE ... WHERE)

### DIFF
--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/metric/MetricFamilyRepositoryImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/metric/MetricFamilyRepositoryImpl.java
@@ -36,11 +36,22 @@ public class MetricFamilyRepositoryImpl implements MetricFamilyRepository {
                 insertStep = insertStep.set(rs.get(i)).newRecord();
             }
 
+            // DO UPDATE ... WHERE, not a plain DO UPDATE: the intent is "fill in a
+            // description if the row does not have one yet, never overwrite one it
+            // already does". But a WHERE clause on DO UPDATE also gates RETURNING --
+            // Postgres skips the row entirely, update and RETURNING both, whenever the
+            // condition does not hold. Ingesting the same metric family a second time
+            // (now with a non-null description already stored) hit exactly that: no
+            // row came back, the caller's Map<String, MetricFamilyPojo> ended up
+            // missing an entry it will .get() further down, and that null exploded on
+            // MetricFamilyPojo::getId with no clue this WHERE clause was the cause.
+            // COALESCE keeps the "never overwrite" behaviour, as a value rather than a
+            // condition, so DO UPDATE -- and RETURNING -- always fire.
             return jooqReactiveOperations.flux(insertStep.set(rs.get(rs.size() - 1))
                 .onConflictOnConstraint(METRIC_FAMILY_NAME_TYPE_UNIT_KEY)
                 .doUpdate()
-                .set(METRIC_FAMILY.DESCRIPTION, DSL.excluded(METRIC_FAMILY.DESCRIPTION))
-                .where(METRIC_FAMILY.DESCRIPTION.isNull())
+                .set(METRIC_FAMILY.DESCRIPTION,
+                    DSL.coalesce(METRIC_FAMILY.DESCRIPTION, DSL.excluded(METRIC_FAMILY.DESCRIPTION)))
                 .returning(METRIC_FAMILY.fields()));
         }).map(r -> r.into(MetricFamilyPojo.class));
     }

--- a/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/api/ingestion/MetricFamilyReingestionTest.java
+++ b/odd-platform-api/src/test/java/org/opendatadiscovery/oddplatform/api/ingestion/MetricFamilyReingestionTest.java
@@ -1,0 +1,71 @@
+package org.opendatadiscovery.oddplatform.api.ingestion;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.opendatadiscovery.oddplatform.BaseIngestionTest;
+import org.opendatadiscovery.oddplatform.api.contract.model.DataSource;
+import org.opendatadiscovery.oddplatform.api.ingestion.utils.IngestionModelGenerator;
+import org.opendatadiscovery.oddplatform.ingestion.contract.model.DataEntity;
+import org.opendatadiscovery.oddplatform.ingestion.contract.model.DataEntityList;
+import org.opendatadiscovery.oddplatform.ingestion.contract.model.DataEntityType;
+import org.opendatadiscovery.oddplatform.ingestion.contract.model.DataSet;
+import org.opendatadiscovery.oddplatform.ingestion.contract.model.MetricSet;
+import org.opendatadiscovery.oddplatform.ingestion.contract.model.MetricSetList;
+import org.springframework.core.io.ClassPathResource;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Regression test for a metric family with a non-null {@code help} (description)
+ * being ingested twice: {@link org.opendatadiscovery.oddplatform.repository.metric
+ * .MetricFamilyRepositoryImpl#createOrUpdateMetricFamilies} used to build its
+ * upsert as {@code ON CONFLICT DO UPDATE ... WHERE description IS NULL RETURNING *},
+ * and Postgres skips both the update and RETURNING for a conflicting row whenever
+ * that WHERE clause does not hold -- which it never does once a description has
+ * been stored once. The second ingest of the same family then produced a
+ * {@code Map<String, MetricFamilyPojo>} missing that family's entry, and a later
+ * {@code MetricFamilyPojo::getId} on the resulting null threw the NPE this
+ * reproduces without.
+ *
+ * <p>{@code gauge_and_count.json}, which the sibling {@link MetricsIngestionTest}
+ * already re-ingests, never exercises this: it sets no {@code help}, so the
+ * WHERE clause it used to depend on stayed true (still null) on every re-ingest.
+ */
+public class MetricFamilyReingestionTest extends BaseIngestionTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void reingestingAFamilyWithADescriptionDoesNotFail() throws IOException {
+        final DataSource createdDataSource = createDataSource();
+
+        final DataEntity datasetToIngest = IngestionModelGenerator
+            .generateSimpleDataEntity(DataEntityType.TABLE)
+            .dataset(new DataSet().fieldList(IngestionModelGenerator.generateDatasetFields(5)).rowsNumber(1000L));
+
+        final var dataEntityList = new DataEntityList()
+            .dataSourceOddrn(createdDataSource.getOddrn())
+            .items(List.of(datasetToIngest));
+
+        ingestAndAssert(dataEntityList);
+        extractIngestedEntityIdAndAssert(createdDataSource);
+
+        final MetricSetList metricSetList = createMetrics(datasetToIngest.getOddrn(), "metrics/gauge_with_help.json");
+        // First push creates the family and stores its description. Before the
+        // fix, this second push -- same name, type, unit and description -- 500s.
+        ingestMetrics(metricSetList);
+        ingestMetrics(createMetrics(datasetToIngest.getOddrn(), "metrics/gauge_with_help.json"));
+    }
+
+    private MetricSetList createMetrics(final String oddrn,
+                                        final String fileName) throws IOException {
+        final MetricSetList metricSetList = new MetricSetList();
+        final List<MetricSet> items = new ArrayList<>();
+        final MetricSet metricSet =
+            objectMapper.readValue(new ClassPathResource(fileName).getInputStream(), MetricSet.class);
+        metricSet.setOddrn(oddrn);
+        items.add(metricSet);
+        metricSetList.setItems(items);
+        return metricSetList;
+    }
+}

--- a/odd-platform-api/src/test/resources/metrics/gauge_with_help.json
+++ b/odd-platform-api/src/test/resources/metrics/gauge_with_help.json
@@ -1,0 +1,28 @@
+{
+  "metric_families": [
+    {
+      "name": "http_requests",
+      "type": "GAUGE",
+      "unit": "req/sec",
+      "help": "Number of HTTP requests",
+      "metrics": [
+        {
+          "labels": [
+            {
+              "name": "env",
+              "value": "prod"
+            }
+          ],
+          "metric_points": [
+            {
+              "timestamp": "1676399903",
+              "gauge_value": {
+                "value": 200
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## The bug

`POST /ingestion/metrics` 500s the second time it sees a metric family that
already has a description stored — same name/type/unit, description
identical or not.

```
java.lang.NullPointerException: Cannot invoke
"MetricFamilyPojo.getId()" because "metricFamilyPojo" is null
```

## Root cause

`MetricFamilyRepositoryImpl.createOrUpdateMetricFamilies()` builds:

```java
.onConflictOnConstraint(METRIC_FAMILY_NAME_TYPE_UNIT_KEY)
.doUpdate()
.set(METRIC_FAMILY.DESCRIPTION, DSL.excluded(METRIC_FAMILY.DESCRIPTION))
.where(METRIC_FAMILY.DESCRIPTION.isNull())
.returning(METRIC_FAMILY.fields())
```

— "fill in a description if the row doesn't have one, never overwrite one it
does." Postgres's `DO UPDATE ... WHERE` skips the row **entirely** when the
condition is false: no update, and no `RETURNING` row either. Once a family's
description has been stored once, every later push of that family fails the
`WHERE`, so `RETURNING` comes back empty for it.

`InternalIngestionMetricsServiceImpl.ingestMetrics()` collects this `Flux`
into a `Map<String, MetricFamilyPojo>` and later does
`familiesMap.get(buildMetricFamilyKey(...))` in `extractSeriesAndPoints()`.
A family `RETURNING` skipped is missing from that map, `.get()` returns
`null`, and `MetricFamilyPojo::getId` on it is the reported NPE.

This is why `MetricsIngestionTest.gaugeAndCounterTest()` — which already
re-ingests the same family three times — doesn't already catch it:
`gauge_and_count.json` sets no `help`, so the family's description stays
`null` and the `WHERE` clause keeps passing on every re-ingest. The bug only
shows once a description is actually set, which `help` on a real Prometheus-
style metric family normally is.

## The fix

Same intent, expressed as a value instead of a condition:

```java
.set(METRIC_FAMILY.DESCRIPTION,
    DSL.coalesce(METRIC_FAMILY.DESCRIPTION, DSL.excluded(METRIC_FAMILY.DESCRIPTION)))
```

`DO UPDATE` now always fires — a no-op when the stored description is
already non-null, since `COALESCE` picks it over the incoming one — so
`RETURNING` always yields a row for every input.

## Testing

Added `MetricFamilyReingestionTest`, structured like the existing
`MetricsIngestionTest`: ingest a family with a `help` set (`gauge_with_help.json`,
new fixture), then ingest the identical family again. Before this fix, the
second `ingestMetrics()` call's `.expectStatus().isCreated()` assertion fails
with the 500 above.

**Verified end-to-end** in a Linux `eclipse-temurin:17-jdk` container, which is how CI builds it. (An earlier version of this description said the build could not run, because of a Jib configuration error on Windows. That error did not happen on Linux with the same JDK 17 and Gradle 8.5.)

| code | `MetricFamilyReingestionTest` | `MetricsIngestionTest` |
|---|---|---|
| this PR | passes (1/1) | passes (2/2) |
| upsert reverted to `DO UPDATE ... WHERE description IS NULL` | **fails**: the second `ingestMetrics()` returns `500 INTERNAL_SERVER_ERROR`, with the `NullPointerException` from `MetricFamilyPojo::getId` | -- |

So the new test reproduces #1882 without the fix and passes with it, and the existing re-ingest test, whose fixture has no description, still passes with the now-unconditional `DO UPDATE`.

Fixes #1882.

