### PR TITLE
fix: ERD relationships 500 when a column has two dataset_field rows

### DIFF
--- a/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveRelationshipsRepositoryImpl.java
+++ b/odd-platform-api/src/main/java/org/opendatadiscovery/oddplatform/repository/reactive/ReactiveRelationshipsRepositoryImpl.java
@@ -242,10 +242,15 @@ public class ReactiveRelationshipsRepositoryImpl
             return null;
         }
 
+        // toMap with no merge function throws on a duplicate key rather than
+        // choosing one -- and a column two sources describe differently is exactly
+        // that: two dataset_field rows sharing an ODDRN. Keep the higher id, the
+        // more recently ingested definition, matching what the Structure tab shows.
         final Map<String, DatasetFieldPojo> datasetFieldMap =
             jooqRecordHelper.extractAggRelation(record, AGG_ERD_DATASET_FIELDS, DatasetFieldPojo.class)
                 .stream()
-                .collect(Collectors.toMap(DatasetFieldPojo::getOddrn, identity()));
+                .collect(Collectors.toMap(DatasetFieldPojo::getOddrn, identity(),
+                    (a, b) -> a.getId() > b.getId() ? a : b));
 
         final List<Pair<
             Pair<String, DatasetFieldPojo>,


### PR DESCRIPTION
## The bug

`GET /api/datasets/{id}/relationships` 500s as soon as any column behind an
ERD relationship has more than one `dataset_field` row:

```
java.lang.IllegalStateException: Duplicate key ...customer_id
  (attempted merging values DatasetFieldPojo(...) and DatasetFieldPojo(...))
	at java.base/java.util.stream.Collectors.duplicateKeyException
	at ReactiveRelationshipsRepositoryImpl.extractErdDetails(...:248)
```

The relationship is stored correctly — `relationships` and
`erd_relationship_details` both hold the right rows. Only reading it back
through this endpoint throws, so the Relationships tab shows "No information
to display" with an `Internal Server Error` toast for an affected dataset.

## Cause

A column gets a new `dataset_field` row whenever its definition changes: a different `logical_type`, `is_nullable` or `is_primary_key` is enough. All of those rows keep the same ODDRN. The ERD query joins `dataset_field` on ODDRN alone, across **every** dataset version, so it gets back one row per definition the column has ever had.

`extractErdDetails()` collects those rows into a `Map<String, DatasetFieldPojo>` keyed by ODDRN with `Collectors.toMap(keyMapper, valueMapper)`. Without a merge function, a duplicate key throws instead of resolving to one row.

So this isn't limited to two sources disagreeing about a column. Any column whose definition has changed even once triggers it, including when a single source just evolves its schema.

## Fix

```java
.collect(Collectors.toMap(DatasetFieldPojo::getOddrn, identity(),
    BinaryOperator.maxBy(Comparator.comparing(DatasetFieldPojo::getId))));
```

Keeping the highest id gives the row the Structure tab shows. That follows from ingestion, not from any tie-break in the read path:

- `DatasetFieldServiceImpl.buildDatasetFieldIngestionDto` compares each incoming field with the row in the **latest** dataset version (`getLastVersionDatasetFieldsByOddrns`). It creates a new row only when the definition differs and reuses that row otherwise.
- A new row always gets a higher id, so the latest version's row is always the newest row for its ODDRN.
- The Structure tab reads the latest version, via `getLatestDatasetVersion` → `dataset_structure` → `dataset_field`.

The code comment now says this too.

## Also found, not touched

The same `Collectors.toMap(DatasetFieldPojo::getOddrn, ...)` shape, with no
merge function, exists in six other places: `DatasetStructureServiceImpl`,
`DatasetVersionServiceImpl`, `DatasetFieldServiceImpl`,
`DatasetFieldMetadataIngestionServiceImpl`, `ExternalTagIngestionRequestProcessor`,
`ReactiveDatasetVersionRepositoryImpl`. I left these alone: several read a
query already scoped to one dataset version or structure, where a duplicate
ODDRN plausibly cannot occur, and confirming which do and don't needs tracing
each query's scope as carefully as the one in this PR — more than I could do
confidently without your context on which of these can actually see two rows
per key. Flagging in case it's useful.

## Testing

`ErdRelationshipChangedColumnTest`, an integration test on `BaseIngestionTest`. It ingests two tables, changes one column's nullability, which gives a second `dataset_field` row under the same ODDRN, then ingests an ERD relationship on that column. It asserts:

- `GET /api/relationships/erd/{id}` returns 200;
- the pair's `source_dataset_field_id` equals the id `GET /api/datasets/{id}/structure` returns for that column. This checks the Structure-tab argument above directly instead of relying on it.

Mutation-checked, so the test is known to catch both failures:

| merge function | result |
|---|---|
| `maxBy` (this PR) | passes |
| `minBy` | fails, on the id comparison |
| none (the original `toMap`) | fails, 500, `Duplicate key <oddrn>` in the log |

Built and run in a Linux `eclipse-temurin:17-jdk` container, as CI does: `checkstyleMain`, `checkstyleTest` and the test pass. (The Jib configuration error mentioned in #1896 happened on Windows and did not happen on Linux with the same JDK 17 and Gradle 8.5.)

Fixes #1880.

